### PR TITLE
Add CNAME record

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -57,3 +57,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./_build/html
           enable_jekyll: false
+          cname: foundations.projectpythia.org


### PR DESCRIPTION
This makes the book accessible at the following URL: foundations.projectpythia.org

Unless folks want a different URL, I will merge this once the CI checks are complete. 

Cc @brian-rose