### PR TITLE
Add conda development env file

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        shell: bash
+        shell: bash -l {0}
     if: github.repository == 'ProjectPythia/pythia-foundations'
     steps:
       - name: Cancel previous runs
@@ -36,7 +36,6 @@ jobs:
           environment-file: environment.yml
           mamba-version: '*'
           use-mamba: true
-          miniforge-variant: Mambaforge
 
       # Build the book
       - name: Build the book

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -21,14 +21,22 @@ jobs:
         shell: bash
     if: github.repository == 'ProjectPythia/pythia-foundations'
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+      - name: Cancel previous runs
+        uses: styfle/cancel-workflow-action@0.8.0
         with:
-          python-version: 3.7
-      - name: Install dependencies
-        run: |
-          python -m pip install -r requirements.txt
+          access_token: ${{ github.token }}
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@master
+        with:
+          channels: conda-forge
+          channel-priority: strict
+          activate-environment: pythia-book-dev
+          auto-update-conda: false
+          python-version: 3.8
+          environment-file: environment.yml
+          mamba-version: '*'
+          use-mamba: true
+          miniforge-variant: Mambaforge
 
       # Build the book
       - name: Build the book

--- a/README.md
+++ b/README.md
@@ -5,3 +5,35 @@ This is the source repository for the Project Pythia Foundations content collect
 The rendered site can be found (for now) at https://projectpythia.org/pythia-foundations/
 
 The book is powered by [Jupyter Book](https://jupyterbook.org/intro.html).
+
+## For Contributors
+
+### Create conda environment
+
+The first time you check out this repository, run:
+
+```bash
+$ conda env update -f environment.yml
+```
+
+This will create or update the dev environment (`pythia-book-dev`).
+
+### `pre-commit` hooks
+
+This repository includes `pre-commit` hooks (defined in `.pre-commit-config.yaml`). To activate/install these pre-commit hooks, run:
+
+```bash
+$ conda activate pythia-book-dev
+$ pre-commit install
+```
+
+_NOTE_: The `pre-commit` package is already installed via the `pythia-book-dev` conda environment.
+
+### Building the book locally
+
+To build the book locally, run the following:
+
+```bash
+$ conda activate pythia-book-dev
+$ jupyter-book build .
+```

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,9 @@
+name: pythia-book-dev
+channels:
+  - conda-forge
+dependencies:
+  - python=3.8
+  - jupyter-book
+  - matplotlib
+  - numpy
+  - pre-commmit

--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,4 @@ dependencies:
   - jupyter-book
   - matplotlib
   - numpy
-  - pre-commmit
+  - pre-commit

--- a/landing-page.md
+++ b/landing-page.md
@@ -5,7 +5,6 @@ Brought to you by [Project Pythia](https://projectpythia.org), this collection w
 All code is licensed under Apache-2.0. All other content is licensed
 under Creative Commons BY 4.0 [(CC BY 4.0)](https://creativecommons.org/licenses/by/4.0/).
 
-
 ```{note}
 This content is under construction!
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-jupyter-book
-matplotlib
-numpy


### PR DESCRIPTION
The environment file includes `pre-commit`. This should help with running the linting pre-commit hooks. 