### PR TITLE
Add suggest edits to top repo button

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -33,5 +33,6 @@ launch_buttons:
 html:
   use_issues_button: true
   use_repository_button: true
+  use_edit_page_button: true
   extra_footer: |
     All code in Pythia Foundations is licensed under Apache 2.0. All other non-code content is licensed under <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons BY 4.0 (CC BY 4.0)</a>.

--- a/_config.yml
+++ b/_config.yml
@@ -36,3 +36,4 @@ html:
   use_edit_page_button: true
   extra_footer: |
     All code in Pythia Foundations is licensed under Apache 2.0. All other non-code content is licensed under <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons BY 4.0 (CC BY 4.0)</a>.
+    We want your feedback! See the "open issue" and "suggest edit" buttons under the GitHub logo at the top of this page.

--- a/environment.yml
+++ b/environment.yml
@@ -7,5 +7,5 @@ dependencies:
   - matplotlib
   - numpy
   - pre-commit
-  - xarrray
+  - xarray
   - cartopy

--- a/environment.yml
+++ b/environment.yml
@@ -7,3 +7,5 @@ dependencies:
   - matplotlib
   - numpy
   - pre-commit
+  - xarrray
+  - cartopy

--- a/preamble/how-to-contribute.md
+++ b/preamble/how-to-contribute.md
@@ -8,4 +8,6 @@ This site is built with [JupyterBook](https://jupyterbook.org).
 
 A full contributor's guide will appear here, cross-referencing our tutorials on open Pull Requests on GitHub.
 
+A simple way to comment on anything you find in this book is to use the "open issue" and "suggest edit" buttons under the GitHub Octocat logo at the top of each page. These links will take you to GitHub where the source material for the book is hosted. You'll need a free (and broadly useful) GitHub account.
+
 Basic instructions on how to build the JupyterBook locally can be found on the README page of the book's [source repository on GitHub](https://github.com/ProjectPythia/pythia-foundations).


### PR DESCRIPTION
Jupyter book has a built-in extra dropdown button for "suggest edits" per our discussion in today's meeting. This is also a chance for anyone in @ProjectPythia/education to see if you're able to push to my PR. I can always wipe out your change if it works. Attached is a screenshot of the important setting beneath the body text of your PR to enable collaboration from project maintainers. This is enabled by default for me, and if it's disabled then external maintainers will not have default write access to your branch on your fork. Otherwise we might have a permissions issue somewhere? Screenshot attached:

![image](https://user-images.githubusercontent.com/24628426/113334826-65507280-92e1-11eb-827d-62f9029b44e3.png)