### PR TITLE
Create notebook template for contributors

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,16 +19,16 @@ execute:
 # Parse and render settings
 parse:
   myst_enable_extensions: # default extensions to enable in the myst parser. See https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html
-    # - amsmath
-    # - colon_fence
-    # - deflist
-    # - dollarmath
-    # - html_admonition
+    - amsmath
+    - colon_fence
+    - deflist
+    - dollarmath
+    - html_admonition
     - html_image
-    # - linkify
-    # - replacements
-    # - smartquotes
-    # - substitution
+    - linkify
+    - replacements
+    - smartquotes
+    - substitution
 
 # Define the name of the latex output file for PDF builds
 latex:

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,21 @@ execute:
   # Do not abort notebook execution for errors, since they may be intentional.
   allow_errors: True
 
+#######################################################################################
+# Parse and render settings
+parse:
+  myst_enable_extensions: # default extensions to enable in the myst parser. See https://myst-parser.readthedocs.io/en/latest/using/syntax-optional.html
+    # - amsmath
+    # - colon_fence
+    # - deflist
+    # - dollarmath
+    # - html_admonition
+    - html_image
+    # - linkify
+    # - replacements
+    # - smartquotes
+    # - substitution
+
 # Define the name of the latex output file for PDF builds
 latex:
   latex_documents:

--- a/_toc.yml
+++ b/_toc.yml
@@ -7,6 +7,8 @@
   chapters:
     - file: preamble/how-to-use
     - file: preamble/how-to-contribute
+      sections:
+        - file: preamble/template
 
 - part: Foundational skills
   chapters:

--- a/preamble/how-to-contribute.md
+++ b/preamble/how-to-contribute.md
@@ -10,6 +10,6 @@ A full contributor's guide will appear here, cross-referencing our tutorials on 
 
 A simple way to comment on anything you find in this book is to use the "open issue" and "suggest edit" buttons under the GitHub Octocat logo at the top of each page. These links will take you to GitHub where the source material for the book is hosted. You'll need a free (and broadly useful) GitHub account.
 
-If you'd like to contribute a Jupyter Notebook to these materials, please reference our [template](preamble/template) viewable on the next page. This template is available to you in `preamble/template.ipynb` if you've cloned the repository, or available as a download [directly from GitHub](https://github.com/ProjectPythia/pythia-foundations/raw/main/preamble/template.ipynb).
+If you'd like to contribute a Jupyter Notebook to these materials, please reference our [template](template) viewable on the next page. This template is available to you in `preamble/template.ipynb` if you've cloned the repository, or available as a download [directly from GitHub](https://github.com/ProjectPythia/pythia-foundations/raw/main/preamble/template.ipynb).
 
 Basic instructions on how to build the JupyterBook locally can be found on the README page of the book's [source repository on GitHub](https://github.com/ProjectPythia/pythia-foundations).

--- a/preamble/how-to-contribute.md
+++ b/preamble/how-to-contribute.md
@@ -10,4 +10,6 @@ A full contributor's guide will appear here, cross-referencing our tutorials on 
 
 A simple way to comment on anything you find in this book is to use the "open issue" and "suggest edit" buttons under the GitHub Octocat logo at the top of each page. These links will take you to GitHub where the source material for the book is hosted. You'll need a free (and broadly useful) GitHub account.
 
+If you'd like to contribute a Jupyter Notebook to these materials, please reference our [template](preamble/template) viewable on the next page. This template is available to you in `preamble/template.ipynb` if you've cloned the repository, or available as a download [directly from GitHub](https://github.com/ProjectPythia/pythia-foundations/raw/main/preamble/template.ipynb).
+
 Basic instructions on how to build the JupyterBook locally can be found on the README page of the book's [source repository on GitHub](https://github.com/ProjectPythia/pythia-foundations).

--- a/preamble/template.ipynb
+++ b/preamble/template.ipynb
@@ -1,0 +1,129 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pythia Foundations Template Notebook\n",
+    "\n",
+    "<img src=\"../images/ProjectPythia_Logo_Final-01-Blue.svg\" width=250 alt=\"Project Pythia Logo\"></img>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overview\n",
+    "1. This is a numbered list of the specific topics"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Prerequisites\n",
+    "Format TBD"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Your first content section\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A content subsection\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Another content subsection\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "subslide"
+    }
+   },
+   "source": [
+    "## Your second content section\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Subsection to the second section"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "body text conclusion\n",
+    "\n",
+    "### What's Next?\n",
+    "link it to other foundations materials"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Resources and References"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  },
+  "toc-autonumbering": false
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/preamble/template.ipynb
+++ b/preamble/template.ipynb
@@ -6,9 +6,9 @@
    "source": [
     "Let's start here! If you can directly link to an image relevant to your notebook, such as [canonical logos](https://github.com/numpy/numpy/blob/main/doc/source/_static/numpylogo.svg), do so here at the top of your notebook. You can do this with Markdown syntax,\n",
     "\n",
-    "> `![<image title>](http://link.com/to/image.png \"image alternate text\")`\n",
+    "> `![<image title>](http://link.com/to/image.png \"image alt text\")`\n",
     "\n",
-    "or edit this cell to see raw HTML `img` demonstration. This is preferred if you need to shrink your embedded image.\n",
+    "or edit this cell to see raw HTML `img` demonstration. This is preferred if you need to shrink your embedded image. **Either way be sure to include `alt` text for any embedded images to make your content more accessible.**\n",
     "\n",
     "<img src=\"../images/ProjectPythia_Logo_Final-01-Blue.svg\" width=250 alt=\"Project Pythia Logo\"></img>"
    ]
@@ -19,7 +19,7 @@
    "source": [
     "# Project Pythia Notebook Template\n",
     "\n",
-    "Next, title your notebook appropriately with a top-level Markdown header, `#`. Do not use this level header anywhere else in the notebook. Our book build process will use this title in the navbar, table of contents, etc. Keep it short, keep it descriptive. Below we have a `---` cell to visually distinguish the next section."
+    "Next, title your notebook appropriately with a top-level Markdown header, `#`. Do not use this level header anywhere else in the notebook. Our book build process will use this title in the navbar, table of contents, etc. Keep it short, keep it descriptive. Follow this with a `---` cell to visually distinguish the transition to the prerequisites section."
    ]
   },
   {
@@ -61,9 +61,7 @@
     "- **Experience level**: with relevant packages or general self-assessed experience as **beginner/user/expert**\n",
     "- **Time to learn**: estimate in minutes or qualitatively as **long/medium/short**\n",
     "- **System requirements**: \n",
-    "    - Populate this list with relevant python packages,\n",
-    "    - system software, or version requirements\n",
-    "    - With links if necessary\n",
+    "    - Populate with any system, version, or non-python software requirements if necessary\n",
     "\n"
    ]
   },
@@ -79,7 +77,7 @@
    "metadata": {},
    "source": [
     "## Imports\n",
-    "Remove this body text and populate the following code cell with all necessary Python imports up-front:"
+    "Begin your body of content with another `---` divider before continuing into this section, then remove this body text and populate the following code cell with all necessary Python imports **up-front**:"
    ]
   },
   {
@@ -170,7 +168,20 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "as well $m = a * t / h$ text! Check out [**any number of helpful Markdown resources**](https://www.markdownguide.org/basic-syntax/) for further customizing your notebooks and the [**Jupyter docs**](https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Working%20With%20Markdown%20Cells.html) for Jupyter-specific formatting information. Don't hesitate to ask questions if you have problems getting it to look *just right*."
+    "as well $m = a * t / h$ text! Similarly, you have access to other $\\LaTeX$ equation [**functionality**](https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Typesetting%20Equations.html) via MathJax (demo below from link),\n",
+    "\n",
+    "\\begin{align}\n",
+    "\\dot{x} & = \\sigma(y-x) \\\\\n",
+    "\\dot{y} & = \\rho x - y - xz \\\\\n",
+    "\\dot{z} & = -\\beta z + xy\n",
+    "\\end{align}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check out [**any number of helpful Markdown resources**](https://www.markdownguide.org/basic-syntax/) for further customizing your notebooks and the [**Jupyter docs**](https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Working%20With%20Markdown%20Cells.html) for Jupyter-specific formatting information. Don't hesitate to ask questions if you have problems getting it to look *just right*."
    ]
   },
   {
@@ -248,7 +259,7 @@
    "metadata": {},
    "source": [
     "## Summary\n",
-    "Above is one more dividing line between your content and this final section. This should be a brief paragraph conclusion about what pieces were learned and how they tied to your objectives. Keep it higher level, and look to reiterate what the most important takeaways were.\n",
+    "Add one final `---` marking the end of your body of content, and then conclude with a brief single paragraph summarizing at a high level the key pieces that were learned and how they tied to your objectives. Look to reiterate what the most important takeaways were.\n",
     "\n",
     "### What's Next?\n",
     "Let Jupyter book tie this to the next (sequential) piece of content that people could move on to down below and in the sidebar. However, if this page uniquely enables your reader to tackle other nonsequential concepts throughout this book, or even external content, link to it here!"
@@ -272,9 +283,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:pythia-book-dev]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-pythia-book-dev-py"
   },
   "language_info": {
    "codemirror_mode": {

--- a/preamble/template.ipynb
+++ b/preamble/template.ipynb
@@ -77,8 +77,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Imports\n",
-    "Remove this body text and populate the following code cell with all necessary (and none unused!) Python imports up-front:"
+    "## Imports\n",
+    "Remove this body text and populate the following code cell with all necessary Python imports up-front:"
    ]
   },
   {
@@ -186,7 +186,7 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition alert alert-info\">\n",
-    "    <p class=\"title\" style=\"font-weight:bold\">Info:</p>\n",
+    "    <p class=\"title\" style=\"font-weight:bold\">Info</p>\n",
     "    Your relevant information here!\n",
     "</div>"
    ]
@@ -203,7 +203,7 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition alert alert-success\">\n",
-    "    <p class=\"title\" style=\"font-weight:bold\">Success:</p>\n",
+    "    <p class=\"title\" style=\"font-weight:bold\">Success</p>\n",
     "    We got this done after all!\n",
     "</div>"
    ]
@@ -213,7 +213,7 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition alert alert-warning\">\n",
-    "    <p class=\"title\" style=\"font-weight:bold\">Warning:</p>\n",
+    "    <p class=\"admonition-title\" style=\"font-weight:bold\">Warning</p>\n",
     "    Be careful!\n",
     "</div>"
    ]
@@ -223,9 +223,16 @@
    "metadata": {},
    "source": [
     "<div class=\"admonition alert alert-danger\">\n",
-    "    <p class=\"title\" style=\"font-weight:bold\">Danger:</p>\n",
+    "    <p class=\"admonition-title\" style=\"font-weight:bold\">Danger</p>\n",
     "    Scary stuff be here.\n",
     "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also suggest checking out Jupyter Book's [brief demonstration](https://jupyterbook.org/content/metadata.html#jupyter-cell-tags) on adding cell tags to your cells in Jupyter Notebook, Lab, or manually. Using these cell tags can allow you to [customize](https://jupyterbook.org/interactive/hiding.html) how your code content is displayed and even [demonstrate errors](https://jupyterbook.org/content/execute.html#dealing-with-code-that-raises-errors) without altogether crashing our loyal army of machines!"
    ]
   },
   {
@@ -242,7 +249,7 @@
     "## Summary\n",
     "Above is one more dividing line between your content and this final section. This should be a brief paragraph conclusion about what pieces were learned and how they tied to your objectives. Keep it higher level, and look to reiterate what the most important takeaways were.\n",
     "\n",
-    "### What Now?\n",
+    "### What's Next?\n",
     "Let Jupyter book tie this to the next (sequential) piece of content that people could move on to down below and in the sidebar. However, if this page uniquely enables your reader to tackle other nonsequential concepts throughout this book, or even external content, link to it here!"
    ]
   },
@@ -252,20 +259,14 @@
    "source": [
     "## Resources and References\n",
     "Finally, be rigorous in your citations and references as necessary. Give credit where credit is do. Also, feel free to link to relevant external material, further reading, documentation, etc. Then you're done! Give yourself a quick review, a high five, and send us a pull request. A few final notes:\n",
-    " - Commit your notebook un-executed with the `Kernel > Restart Kernel and Clear All Outputs...`, our machine will do the work\n",
-    " - Take credit! Provide author contact information if you'd like\n",
-    " - Give credit! Attribute appropriate authorship (alliteration!) for referenced code, information, images, etc.\n",
+    " - `Kernel > Restart Kernel and Run All Cells...` to confirm that your notebook will cleanly run from start to finish\n",
+    " - `Kernel > Restart Kernel and Clear All Outputs...` before committing your notebook, our machines will do the heavy lifting\n",
+    " - Take credit! Provide author contact information if you'd like; if so, consider adding information here at the bottom of your notebook\n",
+    " - Give credit! Attribute appropriate authorship for referenced code, information, images, etc.\n",
     " - Only include what you're legally allowed: **no copyright infringement or plagiarism**\n",
     " \n",
     " Thank you for your contribution!"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/preamble/template.ipynb
+++ b/preamble/template.ipynb
@@ -56,6 +56,7 @@
     "    - With links if necessary\n",
     "- **Uses `environment.yml`**: *True/False* describing if all that's needed is our root `environment.yml` (generally true)\n",
     "- **Concepts**: a table of a few important preceding concepts, tied to other lessons here or externally where able. Explicitly label each concept's importance as *necessary/helpful* and include any relevant commentary\n",
+    "\n",
     "| Concepts | Importance | Notes |\n",
     "| --- | --- | --- |\n",
     "| [Intro to xarray](link-to-notebook) | Necessary | |\n",
@@ -251,13 +252,20 @@
    "source": [
     "## Resources and References\n",
     "Finally, be rigorous in your citations and references as necessary. Give credit where credit is do. Also, feel free to link to relevant external material, further reading, documentation, etc. Then you're done! Give yourself a quick review, a high five, and send us a pull request. A few final notes:\n",
-    " - Commit your notebook un-executed with the `Kernel > Restart Kernel and Clear All Outputs...\", our machine will do the work\n",
+    " - Commit your notebook un-executed with the `Kernel > Restart Kernel and Clear All Outputs...`, our machine will do the work\n",
     " - Take credit! Provide author contact information if you'd like\n",
     " - Give credit! Attribute appropriate authorship (alliteration!) for referenced code, information, images, etc.\n",
     " - Only include what you're legally allowed: **no copyright infringement or plagiarism**\n",
     " \n",
     " Thank you for your contribution!"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/preamble/template.ipynb
+++ b/preamble/template.ipynb
@@ -4,9 +4,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Pythia Foundations Template Notebook\n",
+    "Let's start here! If you can directly link to an image relevant to your notebook, such as [canonical logos](https://github.com/numpy/numpy/blob/main/doc/source/_static/numpylogo.svg), do so here at the top of your notebook. You can do this with Markdown syntax,\n",
+    "\n",
+    "> `![<image title>](http://link.com/to/image.png \"image alternate text\")`\n",
+    "\n",
+    "or edit this cell to see raw HTML `img` demonstration. This is preferred if you need to shrink your embedded image.\n",
     "\n",
     "<img src=\"../images/ProjectPythia_Logo_Final-01-Blue.svg\" width=250 alt=\"Project Pythia Logo\"></img>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pythia Foundations Notebook Template\n",
+    "\n",
+    "Next, title your notebook appropriately with a top-level Markdown header, `#`. Do not use this level header anywhere else in the notebook. Our book build process will use this title in the navbar, table of contents, etc. Keep it short, keep it descriptive. Below we have a `---` cell to visually distinguish the next section."
    ]
   },
   {
@@ -21,7 +34,11 @@
    "metadata": {},
    "source": [
     "## Overview\n",
-    "1. This is a numbered list of the specific topics"
+    "1. This is a numbered list of the specific topics\n",
+    "1. These should map approximately to your main sections of content\n",
+    "1. Or each second-level, `##`, header in your notebook\n",
+    "1. Keep the size and scope of your notebook in check\n",
+    "1. And be sure to let the reader know up front the important concepts they'll be leaving with"
    ]
   },
   {
@@ -29,7 +46,23 @@
    "metadata": {},
    "source": [
     "## Prerequisites\n",
-    "Format TBD"
+    "Following your overview, tell your reader what concepts, packages, or other background information they'll **need** before learning your material. Tie this explicitly with links to other pages here in Foundations or to relevant external resources. Fill out the following information and populate the Markdown table, denoted in this cell with `|` vertical brackets, below:\n",
+    "\n",
+    "- **Experience level**: with relevant packages or general self-assessed experience as *beginner/user/expert*\n",
+    "- **Time to learn**: estimate in minutes or qualitatively as *long/medium/short*\n",
+    "- **System requirements**: \n",
+    "    - Populate this list with relevant python packages,\n",
+    "    - system software, or version requirements\n",
+    "    - With links if necessary\n",
+    "- **Uses `environment.yml`**: *True/False* describing if all that's needed is our root `environment.yml` (generally true)\n",
+    "- **Concepts**: a table of a few important preceding concepts, tied to other lessons here or externally where able. Explicitly label each concept's importance as *necessary/helpful* and include any relevant commentary\n",
+    "| Concepts | Importance | Notes |\n",
+    "| --- | --- | --- |\n",
+    "| [Intro to xarray](link-to-notebook) | Necessary | |\n",
+    "| [Understanding of NetCDF](some-link-to-external-resource) | Helpful | Familiarity with file structure |\n",
+    "| Project management | Helpful | |\n",
+    "\n",
+    "This section was inspired by [this template](https://github.com/alan-turing-institute/the-turing-way/blob/master/book/templates/chapter-template/chapter-landing-page.md) of the wonderful [The Turing Way](https://the-turing-way.netlify.app/welcome.html) Jupyter Book."
    ]
   },
   {
@@ -43,21 +76,67 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Your first content section\n"
+    "### Imports\n",
+    "Remove this body text and populate the following code cell with all necessary (and none unused!) Python imports up-front:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### A content subsection\n"
+    "## Your first content section"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Another content subsection\n"
+    "This is where you begin your first section of material, loosely tied to your objectives stated up front. Tie together your notebook as a narrative, with interspersed Markdown text, images, and more as necessary,"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# as well as any and all of your code cells\n",
+    "print(\"Hello world!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### A content subsection\n",
+    "Divide and conquer your objectives with Markdown subsections, which will populate the helpful navbar in Jupyter Lab and here on the Jupyter Book!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# some subsection code\n",
+    "new = \"helpful information\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Another content subsection\n",
+    "Keep up the good work! A note, *try to avoid using code comments as narrative*, and instead let them only exist as brief clarifications where necessary."
    ]
   },
   {
@@ -68,14 +147,84 @@
     }
    },
    "source": [
-    "## Your second content section\n"
+    "## Your second content section\n",
+    "Here we can move on to our second objective, and we can demonstrate"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Subsection to the second section"
+    "### Subsection to the second section\n",
+    "\n",
+    "#### a quick demonstration\n",
+    "\n",
+    "##### of further and further\n",
+    "\n",
+    "###### header levels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "as well $m = a * t / h$ text! Check out [**any number of helpful Markdown resources**](https://www.markdownguide.org/basic-syntax/) for further customizing your notebooks and the [**Jupyter docs**](https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Working%20With%20Markdown%20Cells.html) for Jupyter-specific formatting information. Don't hesitate to ask questions if you have problems getting it to look *just right*."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Last Section\n",
+    "\n",
+    "If you're comfortable, and as we briefly used for our embedded logo up top, you can embed raw html into Jupyter Markdown cells (edit to see):"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"admonition alert alert-info\">\n",
+    "    <p class=\"title\" style=\"font-weight:bold\">Info:</p>\n",
+    "    Your relevant information here!\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Feel free to copy this around and edit or play around with yourself. Some other `admonitions` you can put in:"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"admonition alert alert-success\">\n",
+    "    <p class=\"title\" style=\"font-weight:bold\">Success:</p>\n",
+    "    We got this done after all!\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"admonition alert alert-warning\">\n",
+    "    <p class=\"title\" style=\"font-weight:bold\">Warning:</p>\n",
+    "    Be careful!\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"admonition alert alert-danger\">\n",
+    "    <p class=\"title\" style=\"font-weight:bold\">Danger:</p>\n",
+    "    Scary stuff be here.\n",
+    "</div>"
    ]
   },
   {
@@ -90,17 +239,24 @@
    "metadata": {},
    "source": [
     "## Summary\n",
-    "body text conclusion\n",
+    "Above is one more dividing line between your content and this final section. This should be a brief paragraph conclusion about what pieces were learned and how they tied to your objectives. Keep it higher level, and look to reiterate what the most important takeaways were.\n",
     "\n",
-    "### What's Next?\n",
-    "link it to other foundations materials"
+    "### What Now?\n",
+    "Let Jupyter book tie this to the next (sequential) piece of content that people could move on to down below and in the sidebar. However, if this page uniquely enables your reader to tackle other nonsequential concepts throughout this book, or even external content, link to it here!"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Resources and References"
+    "## Resources and References\n",
+    "Finally, be rigorous in your citations and references as necessary. Give credit where credit is do. Also, feel free to link to relevant external material, further reading, documentation, etc. Then you're done! Give yourself a quick review, a high five, and send us a pull request. A few final notes:\n",
+    " - Commit your notebook un-executed with the `Kernel > Restart Kernel and Clear All Outputs...\", our machine will do the work\n",
+    " - Take credit! Provide author contact information if you'd like\n",
+    " - Give credit! Attribute appropriate authorship (alliteration!) for referenced code, information, images, etc.\n",
+    " - Only include what you're legally allowed: **no copyright infringement or plagiarism**\n",
+    " \n",
+    " Thank you for your contribution!"
    ]
   }
  ],

--- a/preamble/template.ipynb
+++ b/preamble/template.ipynb
@@ -17,7 +17,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Pythia Foundations Notebook Template\n",
+    "# Project Pythia Notebook Template\n",
     "\n",
     "Next, title your notebook appropriately with a top-level Markdown header, `#`. Do not use this level header anywhere else in the notebook. Our book build process will use this title in the navbar, table of contents, etc. Keep it short, keep it descriptive. Below we have a `---` cell to visually distinguish the next section."
    ]
@@ -48,7 +48,9 @@
     "## Prerequisites\n",
     "This section was inspired by [this template](https://github.com/alan-turing-institute/the-turing-way/blob/master/book/templates/chapter-template/chapter-landing-page.md) of the wonderful [The Turing Way](https://the-turing-way.netlify.app/welcome.html) Jupyter Book.\n",
     "\n",
-    "Following your overview, tell your reader what concepts, packages, or other background information they'll **need** before learning your material. Tie this explicitly with links to other pages here in Foundations or to relevant external resources. Remove this body text, then populate the Markdown table, denoted in this cell with `|` vertical brackets, below, and fill out the information following. In this table, lay out prerequisite concepts by explicitly linking to other Foundations material or external resources, or describe generally helpful concepts. Label each concept explicitly as *helpful/necessary*.\n",
+    "Following your overview, tell your reader what concepts, packages, or other background information they'll **need** before learning your material. Tie this explicitly with links to other pages here in Foundations or to relevant external resources. Remove this body text, then populate the Markdown table, denoted in this cell with `|` vertical brackets, below, and fill out the information following. In this table, lay out prerequisite concepts by explicitly linking to other Foundations material or external resources, or describe generally helpful concepts.\n",
+    "\n",
+    "Label the importance of each concept explicitly as **helpful/necessary**.\n",
     "\n",
     "| Concepts | Importance | Notes |\n",
     "| --- | --- | --- |\n",
@@ -56,8 +58,8 @@
     "| [Understanding of NetCDF](some-link-to-external-resource) | Helpful | Familiarity with metadata structure |\n",
     "| Project management | Helpful | |\n",
     "\n",
-    "- **Experience level**: with relevant packages or general self-assessed experience as *beginner/user/expert*\n",
-    "- **Time to learn**: estimate in minutes or qualitatively as *long/medium/short*\n",
+    "- **Experience level**: with relevant packages or general self-assessed experience as **beginner/user/expert**\n",
+    "- **Time to learn**: estimate in minutes or qualitatively as **long/medium/short**\n",
     "- **System requirements**: \n",
     "    - Populate this list with relevant python packages,\n",
     "    - system software, or version requirements\n",
@@ -264,15 +266,8 @@
     " - Give credit! Attribute appropriate authorship for referenced code, information, images, etc.\n",
     " - Only include what you're legally allowed: **no copyright infringement or plagiarism**\n",
     " \n",
-    " Thank you for your contribution!"
+    "Thank you for your contribution!"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -291,7 +286,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.8.10"
   },
   "toc-autonumbering": false
  },

--- a/preamble/template.ipynb
+++ b/preamble/template.ipynb
@@ -46,7 +46,15 @@
    "metadata": {},
    "source": [
     "## Prerequisites\n",
-    "Following your overview, tell your reader what concepts, packages, or other background information they'll **need** before learning your material. Tie this explicitly with links to other pages here in Foundations or to relevant external resources. Fill out the following information and populate the Markdown table, denoted in this cell with `|` vertical brackets, below:\n",
+    "This section was inspired by [this template](https://github.com/alan-turing-institute/the-turing-way/blob/master/book/templates/chapter-template/chapter-landing-page.md) of the wonderful [The Turing Way](https://the-turing-way.netlify.app/welcome.html) Jupyter Book.\n",
+    "\n",
+    "Following your overview, tell your reader what concepts, packages, or other background information they'll **need** before learning your material. Tie this explicitly with links to other pages here in Foundations or to relevant external resources. Remove this body text, then populate the Markdown table, denoted in this cell with `|` vertical brackets, below, and fill out the information following. In this table, lay out prerequisite concepts by explicitly linking to other Foundations material or external resources, or describe generally helpful concepts. Label each concept explicitly as *helpful/necessary*.\n",
+    "\n",
+    "| Concepts | Importance | Notes |\n",
+    "| --- | --- | --- |\n",
+    "| [Intro to Cartoy](../core/cartopy/01_Cartopy_Intro) | Necessary | |\n",
+    "| [Understanding of NetCDF](some-link-to-external-resource) | Helpful | Familiarity with metadata structure |\n",
+    "| Project management | Helpful | |\n",
     "\n",
     "- **Experience level**: with relevant packages or general self-assessed experience as *beginner/user/expert*\n",
     "- **Time to learn**: estimate in minutes or qualitatively as *long/medium/short*\n",
@@ -54,16 +62,7 @@
     "    - Populate this list with relevant python packages,\n",
     "    - system software, or version requirements\n",
     "    - With links if necessary\n",
-    "- **Uses `environment.yml`**: *True/False* describing if all that's needed is our root `environment.yml` (generally true)\n",
-    "- **Concepts**: a table of a few important preceding concepts, tied to other lessons here or externally where able. Explicitly label each concept's importance as *necessary/helpful* and include any relevant commentary\n",
-    "\n",
-    "| Concepts | Importance | Notes |\n",
-    "| --- | --- | --- |\n",
-    "| [Intro to xarray](link-to-notebook) | Necessary | |\n",
-    "| [Understanding of NetCDF](some-link-to-external-resource) | Helpful | Familiarity with file structure |\n",
-    "| Project management | Helpful | |\n",
-    "\n",
-    "This section was inspired by [this template](https://github.com/alan-turing-institute/the-turing-way/blob/master/book/templates/chapter-template/chapter-landing-page.md) of the wonderful [The Turing Way](https://the-turing-way.netlify.app/welcome.html) Jupyter Book."
+    "\n"
    ]
   },
   {

--- a/preamble/template.ipynb
+++ b/preamble/template.ipynb
@@ -52,7 +52,7 @@
     "\n",
     "| Concepts | Importance | Notes |\n",
     "| --- | --- | --- |\n",
-    "| [Intro to Cartoy](../core/cartopy/01_Cartopy_Intro) | Necessary | |\n",
+    "| [Intro to Cartopy](../core/cartopy/01_Cartopy_Intro) | Necessary | |\n",
     "| [Understanding of NetCDF](some-link-to-external-resource) | Helpful | Familiarity with metadata structure |\n",
     "| Project management | Helpful | |\n",
     "\n",
@@ -257,7 +257,7 @@
    "metadata": {},
    "source": [
     "## Resources and References\n",
-    "Finally, be rigorous in your citations and references as necessary. Give credit where credit is do. Also, feel free to link to relevant external material, further reading, documentation, etc. Then you're done! Give yourself a quick review, a high five, and send us a pull request. A few final notes:\n",
+    "Finally, be rigorous in your citations and references as necessary. Give credit where credit is due. Also, feel free to link to relevant external material, further reading, documentation, etc. Then you're done! Give yourself a quick review, a high five, and send us a pull request. A few final notes:\n",
     " - `Kernel > Restart Kernel and Run All Cells...` to confirm that your notebook will cleanly run from start to finish\n",
     " - `Kernel > Restart Kernel and Clear All Outputs...` before committing your notebook, our machines will do the heavy lifting\n",
     " - Take credit! Provide author contact information if you'd like; if so, consider adding information here at the bottom of your notebook\n",
@@ -266,6 +266,13 @@
     " \n",
     " Thank you for your contribution!"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -284,7 +291,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.8"
   },
   "toc-autonumbering": false
  },

--- a/preamble/template.ipynb
+++ b/preamble/template.ipynb
@@ -60,9 +60,10 @@
     "\n",
     "- **Experience level**: with relevant packages or general self-assessed experience as **beginner/user/expert**\n",
     "- **Time to learn**: estimate in minutes or qualitatively as **long/medium/short**\n",
-    "- **System requirements**: \n",
-    "    - Populate with any system, version, or non-python software requirements if necessary\n",
-    "\n"
+    "- **System requirements**:\n",
+    "    - Populate with any system, version, or non-Python software requirements if necessary\n",
+    "    - Otherwise use the concepts table above and the Imports section below to describe required packages as necessary\n",
+    "    - If no extra requirements, remove the **System requirements** point altogether"
    ]
   },
   {


### PR DESCRIPTION
* Convert the #33 xarray notebook to a template and add it to the preamble
* Add some body to `how-to-contribute` arround it

Drawing inspiration from [our AMS template](https://github.com/Unidata/pyaos-ams-2021/blob/master/instructors/notebook-template/Template.ipynb) and the existing xarray notebook, we've diagrammed out the structure of our notebook template. We will add demonstrative body text, code cells, opinions on tying together the sections, and more shortly. For the moment, feel free to provide feedback on the organization and formatting of sections, headers, etc.

Sidenote: @ProjectPythia/infrastructure let's make a hackathon label!

cc: @mgrover1 @ktyle 