### PR TITLE
Add jupyterlab to pythia-book-dev environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.8
   - jupyter-book
+  - jupyterlab
   - matplotlib
   - numpy
   - pre-commit


### PR DESCRIPTION
Just adds `jupyterlab` to our `environment.yml` file.

This is not strictly necessary for building the book from sources, but I would argue that it's an essential ingredient if we're using this environment for developing new content, and/or directing users to this environment for running our example notebooks.