### PR TITLE
Improve page footer: links to Pythia portal and Contributors guide

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 # Learn more at https://jupyterbook.org/customize/config.html
 
 title: Project Pythia Foundations
-author: The Project Pythia community
+author: the <a href="https://projectpythia.org/">Project Pythia</a> community
 logo: images/ProjectPythia_Logo_Final-01-Blue.png
 
 execute:
@@ -56,4 +56,4 @@ html:
   use_edit_page_button: true
   extra_footer: |
     All code in Pythia Foundations is licensed under Apache 2.0. All other non-code content is licensed under <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons BY 4.0 (CC BY 4.0)</a>.
-    We want your feedback! See the "open issue" and "suggest edit" buttons under the GitHub logo at the top of this page.
+    We want your feedback! See our <a href="https://foundations.projectpythia.org/appendix/how-to-contribute.html">Contributor's Guide</a>.


### PR DESCRIPTION
Modifies the footer displayed at the bottom of every page:
- a link to Project Pythia portal home (https://projectpythia.org) embedded in the text `By the Project Pythia community`
- replace rambling text with link to the Foundations contributors guide page