### PR TITLE
Migrate TOC to new format

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -1,64 +1,59 @@
-# Table of contents
-# Learn more at https://jupyterbook.org/customize/toc.html
-#
-- file: landing-page
-
-- part: Preamble
-  chapters:
-    - file: preamble/how-to-use
-
-- part: Foundational skills
-  chapters:
-    - file: foundations/overview
-    - file: foundations/why-python
-    - file: foundations/getting-started-python
-      sections:
-        - file: foundations/quickstart
-        - file: foundations/how-to-run-python
-          sections:
-            - file: foundations/terminal
-            - file: foundations/jupyter
-            - file: foundations/conda
-    - file: foundations/getting-started-jupyter
-      sections:
-        - file: foundations/jupyter-notebooks
-        - file: foundations/how-to-run-notebooks
-        - file: foundations/markdown
-    - file: foundations/getting-started-github
-      sections:
-        - file: foundations/what-is-github
-        - file: foundations/git
-        - file: foundations/github-pull-request
-
-- part: Core Scientific Python packages
-  chapters:
-    - file: core/overview
-    - file: core/numpy
-      sections:
-        - file: core/numpy/numpy-basics
-        - file: core/numpy/intermediate-numpy
-        - file: core/numpy/numpy-broadcasting
-    - file: core/matplotlib
-      sections:
-        - file: core/matplotlib/matplotlib
-    - file: core/cartopy
-      sections:
-        - file: core/cartopy/cartopy
-    - file: core/datetime
-      sections:
-        - file: core/datetime/datetime
-    - file: core/pandas
-      sections:
-        - file: core/pandas/pandas
-    - file: core/data-formats
-      sections:
-        - file: core/data-formats/netcdf-cf
-    - file: core/xarray
-      sections:
-        - file: core/xarray/xarray
-
-- part: Appendix
-  chapters:
-    - file: appendix/how-to-contribute
-      sections:
-        - file: appendix/template
+format: jb-book
+root: landing-page
+parts:
+  - caption: Preamble
+    chapters:
+      - file: preamble/how-to-use
+  - caption: Foundational skills
+    chapters:
+      - file: foundations/overview
+      - file: foundations/why-python
+      - file: foundations/getting-started-python
+        sections:
+          - file: foundations/quickstart
+          - file: foundations/how-to-run-python
+            sections:
+              - file: foundations/terminal
+              - file: foundations/jupyter
+              - file: foundations/conda
+      - file: foundations/getting-started-jupyter
+        sections:
+          - file: foundations/jupyter-notebooks
+          - file: foundations/how-to-run-notebooks
+          - file: foundations/markdown
+      - file: foundations/getting-started-github
+        sections:
+          - file: foundations/what-is-github
+          - file: foundations/git
+          - file: foundations/github-pull-request
+  - caption: Core Scientific Python packages
+    chapters:
+      - file: core/overview
+      - file: core/numpy
+        sections:
+          - file: core/numpy/numpy-basics
+          - file: core/numpy/intermediate-numpy
+          - file: core/numpy/numpy-broadcasting
+      - file: core/matplotlib
+        sections:
+          - file: core/matplotlib/matplotlib
+      - file: core/cartopy
+        sections:
+          - file: core/cartopy/cartopy
+      - file: core/datetime
+        sections:
+          - file: core/datetime/datetime
+      - file: core/pandas
+        sections:
+          - file: core/pandas/pandas
+      - file: core/data-formats
+        sections:
+          - file: core/data-formats/netcdf-cf
+      - file: core/xarray
+        sections:
+          - file: core/xarray/xarray
+  - caption: Appendix
+    chapters:
+      - file: appendix/how-to-contribute
+        sections:
+          - file: appendix/template

--- a/appendix/how-to-contribute.md
+++ b/appendix/how-to-contribute.md
@@ -5,12 +5,12 @@ This content is under construction!
 ```
 
 General information on how to contribute to any Project Pythia repository
-may be found [here](https://projectpythia.org/pages/contributing.html).
+may be found [here][pythia contributor's guide].
 
 A full contributor's guide will appear here, cross-referencing our tutorials on open Pull Requests on GitHub.
 
 A simple way to comment on anything you find in this book is to use the "open issue" and "suggest edit" buttons under the GitHub Octocat logo at the top of each page. These links will take you to GitHub where the source material for the book is hosted. You'll need a free (and broadly useful) GitHub account. See
-the main [Project Pythia Contributor's Guide](https://projectpythia.org/pages/contributing.html).
+the main [Project Pythia Contributor's Guide][pythia contributor's guide].
 
 ## Contributing a new Jupyter Notebook
 
@@ -59,3 +59,5 @@ open _build/html/index.html
 ```
 
 All code is licensed under Apache 2.0 (including both infrastructure code and example code in the rendered Pythia Foundations book). All other content in Pythia Foundations is licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+
+[pythia contributor's guide]: https://projectpythia.org/contributing.html

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,6 @@ channels:
 dependencies:
   - python=3.8
   - jupyter-book
-  - importlib_resources # temporary workaround
   - jupyterlab
   - matplotlib
   - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - python=3.8
   - jupyter-book
+  - importlib_resources # temporary workaround
   - jupyterlab
   - matplotlib
   - numpy


### PR DESCRIPTION
This should close #91 and get our build working again:
- Migrate the TOC to the new format required by JupyterBook 0.11, as described [here](https://executablebooks.org/en/latest/updates/2021-06-18-update-toc.html)
- Fix the broken link identified in #91