### PR TITLE
Wrap analytics id in quotes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -51,7 +51,7 @@ launch_buttons:
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository
 html:
-  google_analytics_id: G-G57FLM9M46
+  google_analytics_id: 'G-G57FLM9M46'
   use_issues_button: true
   use_repository_button: true
   use_edit_page_button: true


### PR DESCRIPTION
This *might* get the google analytics working for the Foundations site.

I noticed that my other JupyterBook site (which has working analytics) wrapped the ID in double quotes:
https://github.com/brian-rose/ClimateLaboratoryBook/blob/87801650d5f2e374494d8ccfc955b2a3b3000254/_config.yml#L45
This is consistent with the JupyterBook config reference, which shows double quotes: 
https://jupyterbook.org/customize/config.html

I tried using double quotes here, but prettier insisted on changing them to single quotes.