### PR TITLE
Remove obsolete text about README page from How to Contribute

### DIFF
--- a/appendix/how-to-contribute.md
+++ b/appendix/how-to-contribute.md
@@ -14,9 +14,7 @@ the main [Project Pythia Contributor's Guide][pythia contributor's guide].
 
 ## Contributing a new Jupyter Notebook
 
-If you'd like to contribute a Jupyter Notebook to these materials, please reference our [template](template) viewable on the next page. This template is available to you in `appendix/template.ipynb` if you've cloned the repository, or available as a download [directly from GitHub](https://github.com/ProjectPythia/pythia-foundations/raw/main/appendix/template.ipynb).
-
-Basic instructions on how to build the JupyterBook locally can be found on the README page of the book's [source repository on GitHub](https://github.com/ProjectPythia/pythia-foundations).
+If you'd like to contribute a Jupyter Notebook to these materials, please reference our [template](template) viewable on the next page. This template is available to you in `appendix/template.ipynb` if you've cloned the [source repository](https://github.com/ProjectPythia/pythia-foundations), or available as a download [directly from GitHub](https://github.com/ProjectPythia/pythia-foundations/raw/main/appendix/template.ipynb).
 
 ## Building the site
 


### PR DESCRIPTION
Closes #113 