### PR TITLE
Add a codeowners file to facilitate review

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,4 @@ pyproject.toml @ProjectPythia/infrastructure
 setup.cfg @ProjectPythia/infrastructure
 
 # JupyterBook configuration
-_config.yml @ProjectPythia/infrastructure 
+_config.yml @ProjectPythia/infrastructure


### PR DESCRIPTION
Per today's call, here's a `CODEOWNERS` file that should help get reviews. In the end, I took the approach of declaring:
* Everything in the repo is "content" and needs review by the education team...
* ...except as denoted otherwise (like pre-commit and GitHub Actions workflows)