### PR TITLE
Google Analytics Workaround Until Pydata Fix Gets Released

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,6 +37,7 @@ repos:
     rev: v2.2.1
     hooks:
       - id: prettier
+        exclude: '_templates/layout.html'
 
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 0.5.7

--- a/_config.yml
+++ b/_config.yml
@@ -48,10 +48,14 @@ repository:
 launch_buttons:
   binderhub_url: https://mybinder.org
 
+sphinx:
+  config:
+    templates_path: _templates
+
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository
 html:
-  google_analytics_id: 'G-G57FLM9M46'
+  #  google_analytics_id: 'G-G57FLM9M46'
   use_issues_button: true
   use_repository_button: true
   use_edit_page_button: true

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,0 +1,14 @@
+{% extends "sphinx_book_theme/layout.html" %}
+
+{% block extrahead %}
+    <!-- Google Analytics - Global site tag -->
+    <script>
+      window.dataLayer = window.dataLayer || []
+      function gtag() {
+        dataLayer.push(arguments)
+      }
+      gtag('js', new Date())
+
+      gtag('config', 'G-G57FLM9M46')
+    </script>
+{% endblock %}

--- a/_templates/sbt-sidebar-footer.html
+++ b/_templates/sbt-sidebar-footer.html
@@ -1,0 +1,6 @@
+{% if theme_navbar_footer_text %}{% set
+theme_extra_navbar=theme_navbar_footer_text %}{% endif %}
+<!-- To handle the deprecated key -->
+{% if theme_extra_navbar %}
+<div class="navbar_extra_footer">{{ theme_extra_navbar }}</div>
+{% endif %}

--- a/_templates/sbt-sidebar-nav.html
+++ b/_templates/sbt-sidebar-nav.html
@@ -1,0 +1,7 @@
+<nav class="bd-links" id="bd-docs-nav" aria-label="Main">
+  <div class="bd-toc-item active">
+    {{ sbt_generate_nav_html(include_item_names=True,
+    with_home_page=theme_home_page_in_toc, show_depth=theme_show_navbar_depth)
+    }}
+  </div>
+</nav>

--- a/_templates/sidebar-logo.html
+++ b/_templates/sidebar-logo.html
@@ -1,0 +1,9 @@
+<div class="navbar-brand-box">
+  <a class="navbar-brand text-wrap" href="{{ pathto('index') }}">
+    {% if logo %}
+    <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="logo" />
+    {% endif %} {% if docstitle and not theme_logo_only %}
+    <h1 class="site-logo" id="site-title">{{ docstitle }}</h1>
+    {% endif %}
+  </a>
+</div>


### PR DESCRIPTION
Closes #105 

This PR is intended for using a workaround to get Foundations Book's Google Analytics working until this [pydata-sphinx-theme PR ](https://github.com/pydata/pydata-sphinx-theme/pull/439) gets merged and released. 

Brief Explanation of Solution:
- `google_analytics_id ` under `html` tag in `_config.yml` is disabled. Instead, `templates_path` under `sphinx` tag as a `config` item into this file.
- In `_templates/layout.html`, we still extend `sphinx_book_theme/layout.html` that is the default `jupyter-book` that we are already using here.
- In that layout file, we are manually adding the Google Analytics snippet as [suggested by Google](https://developers.google.com/analytics/devguides/collection/gtagjs) to the extrahead before body.
- The other html files in the `_templates` folder are just for avoiding build errors.

The source of the locally generated book seems to be correct as follows:
![image](https://user-images.githubusercontent.com/32553057/131395615-3e6e89b2-fe1e-41c8-b757-2b6373e7976d.png)

There was a slight difference in the footer of the newly generated book compared to the published one in my local as follows; however, there is no such difference in the [generated preview here](https://612d35f8d9efcc29d87c61e8--pythia-foundations.netlify.app/landing-page.html), so I think we don't need to worry about that?
![image](https://user-images.githubusercontent.com/32553057/131396014-a6e5abe3-1f17-44a6-8d6b-e339485875cf.png)
