### PR TITLE
Google Analytics: Add forgotten async script

### DIFF
--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -2,13 +2,12 @@
 
 {% block extrahead %}
     <!-- Google Analytics - Global site tag -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G57FLM9M46"></script>
     <script>
-      window.dataLayer = window.dataLayer || []
-      function gtag() {
-        dataLayer.push(arguments)
-      }
-      gtag('js', new Date())
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
 
-      gtag('config', 'G-G57FLM9M46')
+        gtag('config', 'G-G57FLM9M46');
     </script>
 {% endblock %}


### PR DESCRIPTION
Google Analytics did not start working yet since we forgot to add this script:

`<script async src="https://www.googletagmanager.com/gtag/js?id=G-G57FLM9M46"></script>`

which this PR adds