### PR TITLE
Fix write permission issue that arises during pull_request events

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -25,42 +25,6 @@ jobs:
         uses: styfle/cancel-workflow-action@0.9.1
         with:
           access_token: ${{ github.token }}
-      - name: Set message value
-        run: |
-          echo "comment_message=This pull request is being automatically built with GitHub Action + Netlify. To see the status of your deployment, click below." >> $GITHUB_ENV
-      - name: Find Comment
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v1
-        id: fc
-        with:
-          issue-number: '${{ github.event.number }}'
-          comment-author: 'github-actions[bot]'
-          body-includes: '${{ env.comment_message }}'
-      - name: Create comment
-        if: |
-          github.event_name == 'pull_request'
-          && steps.fc.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          issue-number: ${{ github.event.number }}
-          body: |
-            ${{ env.comment_message }}
-
-            🚧 Deployment in progress for git commit SHA: ${{ github.event.pull_request.head.sha }}
-
-      - name: Update comment
-        if: |
-          github.event_name == 'pull_request'
-          && steps.fc.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v1
-        with:
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          edit-mode: replace
-          body: |
-            ${{ env.comment_message }}
-
-            🚧 Deployment in progress for git commit SHA: ${{ github.event.pull_request.head.sha }}
-
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@master
         with:

--- a/.github/workflows/preview-book.yaml
+++ b/.github/workflows/preview-book.yaml
@@ -15,20 +15,40 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v2
-
       - name: Set message value
         run: |
-          echo "comment_message=This pull request is being automatically built with GitHub Action + Netlify. To see the status of your deployment, click below." >> $GITHUB_ENV
-
+          echo "comment_message=This pull request is being automatically built with [GitHub Actions](https://github.com/features/actions) and [Netlify](https://www.netlify.com/). To see the status of your deployment, click below." >> $GITHUB_ENV
       - name: Find Pull Request
-        uses: juliangruber/find-pull-request-action@v1
+        uses: actions/github-script@v4
         id: find-pull-request
         with:
-          branch: ${{ github.event.workflow_run.head_branch }}
+          script: |
+            let pullRequestNumber = ''
+            let pullRequestHeadSHA = ''
+            core.info('Finding pull request...')
+
+            const pullRequests = await github.pulls.list({owner: context.repo.owner, repo: context.repo.repo})
+            for (let pullRequest of pullRequests.data) {
+              if(pullRequest.head.sha === context.payload.workflow_run.head_commit.id) {
+                  pullRequestHeadSHA = pullRequest.head.sha
+                  pullRequestNumber = pullRequest.number
+                  break
+              }
+            }
+            core.setOutput('number', pullRequestNumber)
+            core.setOutput('sha', pullRequestHeadSHA)
+            if(pullRequestNumber === '') {
+              core.info(
+                 `No pull request associated with git commit SHA: ${context.payload.workflow_run.head_commit.id}`
+              )
+            }
+            else{
+              core.info(`Found pull request ${pullRequestNumber}, with head sha: ${pullRequestHeadSHA}`)
+            }
 
       - name: Find Comment
         uses: peter-evans/find-comment@v1
-        if: steps.find-pull-request.outputs.number  != ''
+        if: steps.find-pull-request.outputs.number != ''
         id: fc
         with:
           issue-number: '${{ steps.find-pull-request.outputs.number }}'
@@ -38,26 +58,27 @@ jobs:
       - name: Create comment
         if: |
           github.event.workflow_run.conclusion != 'success'
+          && steps.find-pull-request.outputs.number != ''
           && steps.fc.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@v1
         with:
           issue-number: ${{ steps.find-pull-request.outputs.number }}
           body: |
             ${{ env.comment_message }}
-            🚧 Deployment in progress for git commit SHA: ${{ steps.find-pull-request.outputs.head-sha }}
+            🚧 Deployment in progress for git commit SHA: ${{ steps.find-pull-request.outputs.sha }}
 
       - name: Update comment
         if: |
           github.event.workflow_run.conclusion != 'success'
+          && steps.find-pull-request.outputs.number != ''
           && steps.fc.outputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v1
         with:
-          token: ${{ steps.generate-token.outputs.token }}
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace
           body: |
             ${{ env.comment_message }}
-            🚧 Deployment in progress for git commit SHA: ${{ steps.find-pull-request.outputs.head-sha }}
+            🚧 Deployment in progress for git commit SHA: ${{ steps.find-pull-request.outputs.sha }}
 
       - name: Download Artifact Book
         uses: dawidd6/action-download-artifact@v2.14.1
@@ -90,6 +111,7 @@ jobs:
       - name: Update Jupyter Book Preview comment
         if: |
           github.event.workflow_run.conclusion == 'success'
+          && steps.find-pull-request.outputs.number != ''
           && steps.fc.outputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v1
         with:
@@ -98,5 +120,5 @@ jobs:
           body: |
             ${{ env.comment_message }}
 
-            📚 Git commit SHA:  ${{ steps.find-pull-request.outputs.head-sha }}
+            🔍 Git commit SHA:  ${{ steps.find-pull-request.outputs.sha }}
             ✅ Deployment Preview URL: ${{ steps.netlify.outputs.deploy-url }}

--- a/.github/workflows/preview-book.yaml
+++ b/.github/workflows/preview-book.yaml
@@ -4,6 +4,7 @@ on:
     workflows:
       - deploy-book
     types:
+      - requested
       - completed
 jobs:
   deploy:
@@ -14,30 +15,6 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v2
-      - name: Download Artifact Book
-        uses: dawidd6/action-download-artifact@v2.14.1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: deploy.yaml
-          run_id: ${{ github.event.workflow_run.id }}
-          name: book-zip
-      - name: Unzip book
-        run: |
-          rm -rf ./_build/html
-          unzip book.zip
-          rm -f book.zip
-      - name: Deploy to Netlify
-        id: netlify
-        uses: nwtgck/actions-netlify@v1.2
-        with:
-          publish-dir: ./_build/html
-          production-deploy: false
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          enable-commit-comment: false
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 5
 
       - name: Set message value
         run: |
@@ -58,8 +35,62 @@ jobs:
           comment-author: 'github-actions[bot]'
           body-includes: '${{ env.comment_message }}'
 
+      - name: Create comment
+        if: |
+          github.event.workflow_run.conclusion != 'success'
+          && steps.fc.outputs.comment-id == ''
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          issue-number: ${{ steps.find-pull-request.outputs.number }}
+          body: |
+            ${{ env.comment_message }}
+            🚧 Deployment in progress for git commit SHA: ${{ steps.find-pull-request.outputs.head-sha }}
+
+      - name: Update comment
+        if: |
+          github.event.workflow_run.conclusion != 'success'
+          && steps.fc.outputs.comment-id != ''
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          edit-mode: replace
+          body: |
+            ${{ env.comment_message }}
+            🚧 Deployment in progress for git commit SHA: ${{ steps.find-pull-request.outputs.head-sha }}
+
+      - name: Download Artifact Book
+        uses: dawidd6/action-download-artifact@v2.14.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: deploy.yaml
+          run_id: ${{ github.event.workflow_run.id }}
+          name: book-zip
+
+      - name: Unzip book
+        run: |
+          rm -rf ./_build/html
+          unzip book.zip
+          rm -f book.zip
+
+      # Push the book's HTML to Netlify and get the preview URL
+      - name: Deploy to Netlify
+        id: netlify
+        uses: nwtgck/actions-netlify@v1.2
+        with:
+          publish-dir: ./_build/html
+          production-deploy: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          enable-commit-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 5
+
       - name: Update Jupyter Book Preview comment
-        if: steps.fc.outputs.comment-id != ''
+        if: |
+          github.event.workflow_run.conclusion == 'success'
+          && steps.fc.outputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@v1
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
Addresses https://github.com/ProjectPythia/pythia-foundations/pull/139#issuecomment-921190200. 

GitHub restricts permissions granted to the default `GITHUB_TOKEN`:

> With the exception of GITHUB_TOKEN, secrets are not passed to the runner when a workflow is triggered from a forked repository. The permissions for the GITHUB_TOKEN in forked repositories is read-only. For more information, see "Authenticating with the GITHUB_TOKEN."

See the [docs for more](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token). 

To circumvent this restriction, I moved the workflow steps that need `GTIHUB_TOKEN` with write permissions to the `preview-book` workflow which is trigger on `on: workflow_run:`
