### PR TITLE
Add documentation on conda update --all

### DIFF
--- a/appendix/how-to-contribute.md
+++ b/appendix/how-to-contribute.md
@@ -58,7 +58,7 @@ open _build/html/index.html
 
 ### Keeping your dev environment up to date
 
-It's good practice to update the packages in your `pythia-book-dev` conda environment frequently to their latest versions, especially if it's been a while since you used it.
+It's good practice to update the packages in your `pythia-book-dev` conda environment frequently to their latest versions, especially if it's been a while since you used it. If the `jupyter-book build .` command above generates error messages, that is a good indication that your conda environment may be out of date.
 
 To update all packages in the currently activated environment to their latest versions, do this:
 

--- a/appendix/how-to-contribute.md
+++ b/appendix/how-to-contribute.md
@@ -23,7 +23,7 @@ If you'd like to contribute a Jupyter Notebook to these materials, please refere
 The first time you check out this repository, run:
 
 ```bash
-$ conda env update -f environment.yml
+conda env update -f environment.yml
 ```
 
 This will create or update the dev environment (`pythia-book-dev`).
@@ -33,8 +33,8 @@ This will create or update the dev environment (`pythia-book-dev`).
 This repository includes `pre-commit` hooks (defined in `.pre-commit-config.yaml`). To activate/install these pre-commit hooks, run:
 
 ```bash
-$ conda activate pythia-book-dev
-$ pre-commit install
+conda activate pythia-book-dev
+pre-commit install
 ```
 
 This is also a one-time step.
@@ -46,16 +46,24 @@ _NOTE_: The `pre-commit` package is already installed via the `pythia-book-dev` 
 To build the book locally, run the following:
 
 ```bash
-$ conda activate pythia-book-dev
-$ jupyter-book build .
+conda activate pythia-book-dev
+jupyter-book build .
 ```
 
 Finally, you can view the book by opening the file `_build/html/index.html` with your favorite web browser. On most platforms you can simply run:
 
-```
+```bash
 open _build/html/index.html
 ```
 
-All code is licensed under Apache 2.0 (including both infrastructure code and example code in the rendered Pythia Foundations book). All other content in Pythia Foundations is licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+### Keeping your dev environment up to date
+
+It's good practice to update the packages in your `pythia-book-dev` conda environment frequently to their latest versions, especially if it's been a while since you used it.
+
+To update all packages in the currently activated environment to their latest versions, do this:
+
+```bash
+conda update --all
+```
 
 [pythia contributor's guide]: https://projectpythia.org/contributing.html

--- a/foundations/conda.md
+++ b/foundations/conda.md
@@ -86,10 +86,16 @@ conda list
 conda install somepackage
 ```
 
-- Installing a specific version of a package
+- Installing a specific version of a package into current environment
 
 ```
 conda install somepackage=0.17
+```
+
+- Updating all packages in the current environment to the latest versions
+
+```
+conda update --all
 ```
 
 - Checking what conda environments you have


### PR DESCRIPTION
This PR finishes continues to address https://github.com/ProjectPythia/projectpythia.github.io/issues/162 by adding instructions for updating the conda environment in two places:
- Pythia Foundations contributor's guide
- list of useful conda commands in the conda section of Foundations

I also changed the formatting of all the bash shell snippets in the Contributor's Guide to remove the `$ ` prefix from each line. Happy to hear dissenting voices on this, but they interfere with the JupyterBook feature of copying the working example to the clipboard with one click, because the `$ ` characters are copied along with the executable command.