### PR TITLE
Fix breaking changes in github-script v5

### DIFF
--- a/.github/workflows/preview-book.yaml
+++ b/.github/workflows/preview-book.yaml
@@ -27,7 +27,7 @@ jobs:
             let pullRequestHeadSHA = ''
             core.info('Finding pull request...')
 
-            const pullRequests = await github.pulls.list({owner: context.repo.owner, repo: context.repo.repo})
+            const pullRequests = await github.rest.pulls.list({owner: context.repo.owner, repo: context.repo.repo})
             for (let pullRequest of pullRequests.data) {
               if(pullRequest.head.sha === context.payload.workflow_run.head_commit.id) {
                   pullRequestHeadSHA = pullRequest.head.sha


### PR DESCRIPTION
https://github.com/ProjectPythia/pythia-foundations/pull/149 introduced a new version of `github-script` action. This new version includes [breaking changes](https://github.com/actions/github-script#breaking-changes-in-v5) that cause the [CI to fail](https://github.com/ProjectPythia/pythia-foundations/runs/3716520538?check_suite_focus=true)