### PR TITLE
Add nightly build workflow

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -1,0 +1,79 @@
+name: nightly-build
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # Daily “At 00:00”
+jobs:
+  jupyterbook-build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    if: github.repository == 'ProjectPythia/pythia-foundations'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: conda-incubator/setup-miniconda@master
+        continue-on-error: true
+        id: conda
+        with:
+          channels: conda-forge
+          channel-priority: strict
+          activate-environment: pythia-book-dev
+          auto-update-conda: false
+          python-version: 3.8
+          environment-file: environment.yml
+          mamba-version: '*'
+          use-mamba: true
+
+      - name: Build the book
+        continue-on-error: true
+        id: build
+        run: |
+          jupyter-book build .
+
+      - name: Report status
+        if: steps.build.outcome != 'success' || steps.conda.status != 'success'
+        uses: actions/github-script@v5
+        with:
+          script: |
+
+            const title = '⚠️ Nightly build failed ⚠️'
+            const creator = 'github-actions[bot]'
+            const issueLabel = 'CI'
+            const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+            const issue_body = `[Workflow Run URL](${workflow_url})\n\n---\n\nCc @ProjectPythia/core`
+
+            let foundIssue = false
+            const issues = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            })
+            for (let issue of issues.data) {
+              if (
+                issue.user.login === creator &&
+                issue.state === 'open' &&
+                issue.labels.some((label) => label.name === issueLabel)
+              ) {
+                github.rest.issues.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issue.number,
+                  body: issue_body,
+                })
+                core.info(`Updated an existing issue: ${issue.number}.`)
+                foundIssue = true
+                break
+              }
+            }
+
+            if (!foundIssue) {
+              const issue = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: title,
+                body: issue_body,
+                labels: [issueLabel],
+              })
+              core.info(`Opened a new issue: ${issue.number}`)
+            }


### PR DESCRIPTION
- Closes #92

This workflow will be triggered at midnight (UTC) every day. To report failures, this workflow opens a new issue or updates an existing issue  with the following content 




![Screen Shot 2021-10-26 at 4 46 47 PM](https://user-images.githubusercontent.com/13301940/138972457-df826dad-afc5-441e-bf92-df6c373b6e31.png)
 
