### PR TITLE
Fix link format in the netCDF lesson

### DIFF
--- a/core/data-formats/netcdf-cf.ipynb
+++ b/core/data-formats/netcdf-cf.ipynb
@@ -956,7 +956,7 @@
     "\n",
     "- CF Conventions doc ([1.7](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html))\n",
     "- Jonathan Gregory's old [CF presentation](http://cfconventions.org/Data/cf-documents/overview/viewgraphs.pdf)\n",
-    "- [NASA ESDS “Dataset Interoperability Recommendations for Earth Science”][https://earthdata.nasa.gov/user-resources/standards-and-references/dataset-interoperability-recommendations-for-earth-science)\n",
+    "- [NASA ESDS “Dataset Interoperability Recommendations for Earth Science”](https://earthdata.nasa.gov/user-resources/standards-and-references/dataset-interoperability-recommendations-for-earth-science)\n",
     "- CF Data Model (cfdm) python package [tutorial](https://ncas-cms.github.io/cfdm/tutorial.html)\n",
     "- Tim Whiteaker's cfgeom python package (GitHub [repo](https://github.com/twhiteaker/CFGeom))([tutorial]( https://twhiteaker.github.io/CFGeom/tutorial.html))"
    ]


### PR DESCRIPTION
One of the resources links used `[...][...)` by mistake so the link didn't render properly.