### PR TITLE
Clarify how to find the Binder link

### DIFF
--- a/foundations/quickstart.ipynb
+++ b/foundations/quickstart.ipynb
@@ -27,8 +27,8 @@
     "\n",
     "Of course you can simply read through these examples, but it's more fun to ***run them yourself***:\n",
     "\n",
-    "- Find the \"Rocket Ship\" icon at the top of the page\n",
-    "- Click the `Binder` link\n",
+    "- Find the **\"Rocket Ship\"** icon, **located near the top-right of this page**. Hover over this icon to see the drop-down menu.\n",
+    "- Click the `Binder` link from the drop-down menu.\n",
     "- This page will open up as a [Jupyter notebook](jupyter.html) in a working Python environment in the cloud.\n",
     "- Press <kbd>Shift</kbd>+<kbd>Enter</kbd> to execute each code cell\n",
     "- Feel free to make changes and play around!"
@@ -91,7 +91,7 @@
     "- Python defaults to counting from 0 (like C) rather than from 1 (like Fortran).\n",
     "- Function calls in Python always use parentheses: `print()`\n",
     "- The colon `:` denotes the beginning of a definition (here of the repeated code under the `for` loop.\n",
-    "- Code blocks are indentified through indentations.\n",
+    "- Code blocks are identified through indentations.\n",
     "\n",
     "To emphasize this last point, here an example with a two-line repeated block:"
    ]
@@ -621,7 +621,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -635,7 +635,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Addresses user feedback in #226.

I tried to clarify the instructions in the Quickstart notebook on where to find the Binder link.

Also fixed an unrelated typo that I found in that notebook.
