### PR TITLE
Fixed #226 - Quickstart:zero to Python Binder link

### DIFF
--- a/foundations/quickstart.ipynb
+++ b/foundations/quickstart.ipynb
@@ -28,6 +28,7 @@
     "Of course you can simply read through these examples, but it's more fun to ***run them yourself***:\n",
     "\n",
     "- Find the \"Rocket Ship\" icon at the top of the page\n",
+    "- Hover your mouse over the \"Rocket Ship\" until the hidden `Binder` link appears\n",
     "- Click the `Binder` link\n",
     "- This page will open up as a [Jupyter notebook](jupyter.html) in a working Python environment in the cloud.\n",
     "- Press <kbd>Shift</kbd>+<kbd>Enter</kbd> to execute each code cell\n",


### PR DESCRIPTION
Clarified instructions for finding binder link dropdown from rocket ship icon
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
