### PR TITLE
update prereqs in GitHub sections

### DIFF
--- a/foundations/github/basic-git.md
+++ b/foundations/github/basic-git.md
@@ -19,9 +19,9 @@
 | ---------------------------------------------------------- | ---------- | ---------------------------- |
 | [What is GitHub?](what-is-github)                          | Necessary  | GitHub user account required |
 | [GitHub Repositories](github-repos)                        | Necessary  |                              |
-| [Issues and Discussions](github-issues)                    |            |                              |
-| [Cloning and Forking a Repository](github-cloning-forking) |            |                              |
-| [Advanced GitHub Setup](github-setup-advanced)             |            |                              |
+| [Issues and Discussions](github-issues)                    | Recommended         |                              |
+| [Cloning and Forking a Repository](github-cloning-forking) |   Recommended        |                              |
+| [Advanced GitHub Setup](github-setup-advanced)             |    Recommended        |                              |
 
 - **Time to learn**: 45 minutes
 

--- a/foundations/github/basic-git.md
+++ b/foundations/github/basic-git.md
@@ -15,13 +15,13 @@
 
 ## Prerequisites
 
-| Concepts              | Importance | Notes |
-| --------------------- | ---------- | ----- |
-| [What is GitHub?](what-is-github)| Necessary  |  GitHub user account required |
-| [GitHub Repositories](github-repos)| Necessary  |       |
-| [Issues and Discussions](github-issues) |   |       |
-| [Cloning and Forking a Repository](github-cloning-forking) |   |       |
-| [Advanced GitHub Setup](github-setup-advanced) |  |       |
+| Concepts                                                   | Importance | Notes                        |
+| ---------------------------------------------------------- | ---------- | ---------------------------- |
+| [What is GitHub?](what-is-github)                          | Necessary  | GitHub user account required |
+| [GitHub Repositories](github-repos)                        | Necessary  |                              |
+| [Issues and Discussions](github-issues)                    |            |                              |
+| [Cloning and Forking a Repository](github-cloning-forking) |            |                              |
+| [Advanced GitHub Setup](github-setup-advanced)             |            |                              |
 
 - **Time to learn**: 45 minutes
 

--- a/foundations/github/basic-git.md
+++ b/foundations/github/basic-git.md
@@ -17,7 +17,11 @@
 
 | Concepts              | Importance | Notes |
 | --------------------- | ---------- | ----- |
-| Prior GitHub Sections | Necessary  |       |
+| [What is GitHub?](what-is-github)| Necessary  |  GitHub user account required |
+| [GitHub Repositories](github-repos)| Necessary  |       |
+| [Issues and Discussions](github-issues) |   |       |
+| [Cloning and Forking a Repository](github-cloning-forking) |   |       |
+| [Advanced GitHub Setup](github-setup-advanced) |  |       |
 
 - **Time to learn**: 45 minutes
 

--- a/foundations/github/basic-git.md
+++ b/foundations/github/basic-git.md
@@ -15,13 +15,13 @@
 
 ## Prerequisites
 
-| Concepts                                                   | Importance | Notes                        |
-| ---------------------------------------------------------- | ---------- | ---------------------------- |
-| [What is GitHub?](what-is-github)                          | Necessary  | GitHub user account required |
-| [GitHub Repositories](github-repos)                        | Necessary  |                              |
-| [Issues and Discussions](github-issues)                    | Recommended         |                              |
-| [Cloning and Forking a Repository](github-cloning-forking) |   Recommended        |                              |
-| [Advanced GitHub Setup](github-setup-advanced)             |    Recommended        |                              |
+| Concepts                                                   | Importance  | Notes                        |
+| ---------------------------------------------------------- | ----------- | ---------------------------- |
+| [What is GitHub?](what-is-github)                          | Necessary   | GitHub user account required |
+| [GitHub Repositories](github-repos)                        | Necessary   |                              |
+| [Issues and Discussions](github-issues)                    | Recommended |                              |
+| [Cloning and Forking a Repository](github-cloning-forking) | Recommended |                              |
+| [Advanced GitHub Setup](github-setup-advanced)             | Recommended |                              |
 
 - **Time to learn**: 45 minutes
 

--- a/foundations/github/git-branches.md
+++ b/foundations/github/git-branches.md
@@ -20,8 +20,8 @@ The best practices for a simple workflow for suggesting changes to a GitHub repo
 | [GitHub Repositories](github-repos)                        | Necessary   |                              |
 | [Issues and Discussions](github-issues)                    | Recommended |                              |
 | [Cloning and Forking a Repository](github-cloning-forking) | Necessary   |                              |
-| [Advanced GitHub Setup](github-setup-advanced)             |     Recommended        |                              |
-| [Basic Version Control with Git](basic-git)                |   Recommended          |                              |
+| [Advanced GitHub Setup](github-setup-advanced)             | Recommended |                              |
+| [Basic Version Control with Git](basic-git)                | Recommended |                              |
 
 - **Time to learn**: 30 minutes
 

--- a/foundations/github/git-branches.md
+++ b/foundations/github/git-branches.md
@@ -20,8 +20,8 @@ The best practices for a simple workflow for suggesting changes to a GitHub repo
 | [GitHub Repositories](github-repos)                        | Necessary   |                              |
 | [Issues and Discussions](github-issues)                    | Recommended |                              |
 | [Cloning and Forking a Repository](github-cloning-forking) | Necessary   |                              |
-| [Advanced GitHub Setup](github-setup-advanced)             |             |                              |
-| [Basic Version Control with Git](basic-git)                |             |                              |
+| [Advanced GitHub Setup](github-setup-advanced)             |     Recommended        |                              |
+| [Basic Version Control with Git](basic-git)                |   Recommended          |                              |
 
 - **Time to learn**: 30 minutes
 

--- a/foundations/github/git-branches.md
+++ b/foundations/github/git-branches.md
@@ -16,7 +16,13 @@ The best practices for a simple workflow for suggesting changes to a GitHub repo
 
 | Concepts              | Importance | Notes |
 | --------------------- | ---------- | ----- |
-| Prior GitHub Sections | Necessary  |       |
+| [What is GitHub?](what-is-github)| Necessary  |  GitHub user account required |
+| [GitHub Repositories](github-repos)| Necessary  |       |
+| [Issues and Discussions](github-issues) | Recommended |       |
+| [Cloning and Forking a Repository](github-cloning-forking) |  Necessary |       |
+| [Advanced GitHub Setup](github-setup-advanced) |  |       |
+| [Basic Version Control with Git](basic-git) |  |       |
+
 
 - **Time to learn**: 30 minutes
 

--- a/foundations/github/git-branches.md
+++ b/foundations/github/git-branches.md
@@ -14,15 +14,14 @@ The best practices for a simple workflow for suggesting changes to a GitHub repo
 
 ## Prerequisites
 
-| Concepts              | Importance | Notes |
-| --------------------- | ---------- | ----- |
-| [What is GitHub?](what-is-github)| Necessary  |  GitHub user account required |
-| [GitHub Repositories](github-repos)| Necessary  |       |
-| [Issues and Discussions](github-issues) | Recommended |       |
-| [Cloning and Forking a Repository](github-cloning-forking) |  Necessary |       |
-| [Advanced GitHub Setup](github-setup-advanced) |  |       |
-| [Basic Version Control with Git](basic-git) |  |       |
-
+| Concepts                                                   | Importance  | Notes                        |
+| ---------------------------------------------------------- | ----------- | ---------------------------- |
+| [What is GitHub?](what-is-github)                          | Necessary   | GitHub user account required |
+| [GitHub Repositories](github-repos)                        | Necessary   |                              |
+| [Issues and Discussions](github-issues)                    | Recommended |                              |
+| [Cloning and Forking a Repository](github-cloning-forking) | Necessary   |                              |
+| [Advanced GitHub Setup](github-setup-advanced)             |             |                              |
+| [Basic Version Control with Git](basic-git)                |             |                              |
 
 - **Time to learn**: 30 minutes
 

--- a/foundations/github/github-cloning-forking.md
+++ b/foundations/github/github-cloning-forking.md
@@ -7,12 +7,12 @@
 
 ## Prerequisites
 
-| Concepts              | Importance | Notes                        |
-| --------------------- | ---------- | ---------------------------- |
-| [What is GitHub?](what-is-github)| Necessary  |  GitHub user account required |
-| [GitHub Repositories](github-repos)| Necessary  |       |
-| [Issues and Discussions](github-issues) |   |       |
-| Command-line shell    | Helpful    |                              |
+| Concepts                                | Importance | Notes                        |
+| --------------------------------------- | ---------- | ---------------------------- |
+| [What is GitHub?](what-is-github)       | Necessary  | GitHub user account required |
+| [GitHub Repositories](github-repos)     | Necessary  |                              |
+| [Issues and Discussions](github-issues) |            |                              |
+| Command-line shell                      | Helpful    |                              |
 
 - **Time to learn**: 30 minutes
 

--- a/foundations/github/github-cloning-forking.md
+++ b/foundations/github/github-cloning-forking.md
@@ -9,7 +9,9 @@
 
 | Concepts              | Importance | Notes                        |
 | --------------------- | ---------- | ---------------------------- |
-| Prior GitHub Sections | Necessary  | GitHub user account required |
+| [What is GitHub?](what-is-github)| Necessary  |  GitHub user account required |
+| [GitHub Repositories](github-repos)| Necessary  |       |
+| [Issues and Discussions](github-issues) |   |       |
 | Command-line shell    | Helpful    |                              |
 
 - **Time to learn**: 30 minutes

--- a/foundations/github/github-cloning-forking.md
+++ b/foundations/github/github-cloning-forking.md
@@ -11,7 +11,7 @@
 | --------------------------------------- | ---------- | ---------------------------- |
 | [What is GitHub?](what-is-github)       | Necessary  | GitHub user account required |
 | [GitHub Repositories](github-repos)     | Necessary  |                              |
-| [Issues and Discussions](github-issues) |            |                              |
+| [Issues and Discussions](github-issues) |   Recommended       |                              |
 | Command-line shell                      | Helpful    |                              |
 
 - **Time to learn**: 30 minutes

--- a/foundations/github/github-cloning-forking.md
+++ b/foundations/github/github-cloning-forking.md
@@ -7,12 +7,12 @@
 
 ## Prerequisites
 
-| Concepts                                | Importance | Notes                        |
-| --------------------------------------- | ---------- | ---------------------------- |
-| [What is GitHub?](what-is-github)       | Necessary  | GitHub user account required |
-| [GitHub Repositories](github-repos)     | Necessary  |                              |
-| [Issues and Discussions](github-issues) |   Recommended       |                              |
-| Command-line shell                      | Helpful    |                              |
+| Concepts                                | Importance  | Notes                        |
+| --------------------------------------- | ----------- | ---------------------------- |
+| [What is GitHub?](what-is-github)       | Necessary   | GitHub user account required |
+| [GitHub Repositories](github-repos)     | Necessary   |                              |
+| [Issues and Discussions](github-issues) | Recommended |                              |
+| Command-line shell                      | Helpful     |                              |
 
 - **Time to learn**: 30 minutes
 

--- a/foundations/github/github-issues.md
+++ b/foundations/github/github-issues.md
@@ -8,7 +8,8 @@
 
 | Concepts              | Importance | Notes |
 | --------------------- | ---------- | ----- |
-| Prior GitHub Sections | Necessary  |       |
+| [What is GitHub?](what-is-github)| Necessary  |       |
+| [GitHub Repositories](github-repos)| Necessary  |       |
 
 - **Time to learn**: 5 minutes
 

--- a/foundations/github/github-issues.md
+++ b/foundations/github/github-issues.md
@@ -6,10 +6,10 @@
 
 ## Prerequisites
 
-| Concepts              | Importance | Notes |
-| --------------------- | ---------- | ----- |
-| [What is GitHub?](what-is-github)| Necessary  |       |
-| [GitHub Repositories](github-repos)| Necessary  |       |
+| Concepts                            | Importance | Notes |
+| ----------------------------------- | ---------- | ----- |
+| [What is GitHub?](what-is-github)   | Necessary  |       |
+| [GitHub Repositories](github-repos) | Necessary  |       |
 
 - **Time to learn**: 5 minutes
 

--- a/foundations/github/github-setup-advanced.md
+++ b/foundations/github/github-setup-advanced.md
@@ -7,12 +7,12 @@
 
 ## Prerequisites
 
-| Concepts              | Importance | Notes |
-| --------------------- | ---------- | ----- |
-| [What is GitHub?](what-is-github)| Necessary  |  GitHub user account required |
-| [GitHub Repositories](github-repos)| Necessary  |       |
-| [Issues and Discussions](github-issues) |   |       |
-| [Cloning and Forking a Repository](github-cloning-forking) |  |       |
+| Concepts                                                   | Importance | Notes                        |
+| ---------------------------------------------------------- | ---------- | ---------------------------- |
+| [What is GitHub?](what-is-github)                          | Necessary  | GitHub user account required |
+| [GitHub Repositories](github-repos)                        | Necessary  |                              |
+| [Issues and Discussions](github-issues)                    |            |                              |
+| [Cloning and Forking a Repository](github-cloning-forking) |            |                              |
 
 - **Time to learn**: 15 minutes
 

--- a/foundations/github/github-setup-advanced.md
+++ b/foundations/github/github-setup-advanced.md
@@ -11,8 +11,8 @@
 | ---------------------------------------------------------- | ---------- | ---------------------------- |
 | [What is GitHub?](what-is-github)                          | Necessary  | GitHub user account required |
 | [GitHub Repositories](github-repos)                        | Necessary  |                              |
-| [Issues and Discussions](github-issues)                    |            |                              |
-| [Cloning and Forking a Repository](github-cloning-forking) |            |                              |
+| [Issues and Discussions](github-issues)                    |    Recommeneded        |                              |
+| [Cloning and Forking a Repository](github-cloning-forking) |        Recommended    |                              |
 
 - **Time to learn**: 15 minutes
 

--- a/foundations/github/github-setup-advanced.md
+++ b/foundations/github/github-setup-advanced.md
@@ -9,7 +9,10 @@
 
 | Concepts              | Importance | Notes |
 | --------------------- | ---------- | ----- |
-| Prior GitHub Sections | Necessary  |       |
+| [What is GitHub?](what-is-github)| Necessary  |  GitHub user account required |
+| [GitHub Repositories](github-repos)| Necessary  |       |
+| [Issues and Discussions](github-issues) |   |       |
+| [Cloning and Forking a Repository](github-cloning-forking) |  |       |
 
 - **Time to learn**: 15 minutes
 

--- a/foundations/github/github-setup-advanced.md
+++ b/foundations/github/github-setup-advanced.md
@@ -7,12 +7,12 @@
 
 ## Prerequisites
 
-| Concepts                                                   | Importance | Notes                        |
-| ---------------------------------------------------------- | ---------- | ---------------------------- |
-| [What is GitHub?](what-is-github)                          | Necessary  | GitHub user account required |
-| [GitHub Repositories](github-repos)                        | Necessary  |                              |
-| [Issues and Discussions](github-issues)                    |    Recommeneded        |                              |
-| [Cloning and Forking a Repository](github-cloning-forking) |        Recommended    |                              |
+| Concepts                                                   | Importance   | Notes                        |
+| ---------------------------------------------------------- | ------------ | ---------------------------- |
+| [What is GitHub?](what-is-github)                          | Necessary    | GitHub user account required |
+| [GitHub Repositories](github-repos)                        | Necessary    |                              |
+| [Issues and Discussions](github-issues)                    | Recommeneded |                              |
+| [Cloning and Forking a Repository](github-cloning-forking) | Recommended  |                              |
 
 - **Time to learn**: 15 minutes
 


### PR DESCRIPTION
All these sections said "All Previous GitHub Chapters" instead of specifics for their prereqs. This PR addresses that.
Related to #214