### PR TITLE
Clean up Xarray landing page

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -60,7 +60,7 @@ parts:
           - file: core/data-formats/netcdf-cf
       - file: core/xarray
         sections:
-          - file: core/xarray/xarray
+          - file: core/xarray/xarray-intro
           - file: core/xarray/computation-masking
           - file: core/xarray/enso-xarray
   - caption: Appendix

--- a/core/xarray.md
+++ b/core/xarray.md
@@ -1,8 +1,6 @@
-# Xarray
+![xarray Logo](http://xarray.pydata.org/en/stable/_static/dataset-diagram-logo.png "xarray Logo")
 
-```{note}
-This content is under construction!
-```
+# Xarray
 
 This section contains tutorials on using [Xarray][xarray home]. Xarray is used widely in the geosciences and beyond for analysis of gridded N-dimensional datasets.
 

--- a/core/xarray.md
+++ b/core/xarray.md
@@ -1,4 +1,4 @@
-![xarray Logo](http://xarray.pydata.org/en/stable/_static/dataset-diagram-logo.png "xarray Logo")
+![xarray Logo](http://xarray.pydata.org/en/stable/_static/dataset-diagram-logo.png 'xarray Logo')
 
 # Xarray
 

--- a/core/xarray/computation-masking.ipynb
+++ b/core/xarray/computation-masking.ipynb
@@ -49,7 +49,7 @@
     "\n",
     "| Concepts | Importance | Notes |\n",
     "| --- | --- | --- |\n",
-    "| [Introduction to Xarray](./xarray.ipynb) | Necessary | |\n",
+    "| [Introduction to Xarray](xarray-intro) | Necessary | |\n",
     "\n",
     "\n",
     "- **Time to learn**: 60 minutes"
@@ -896,7 +896,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/core/xarray/enso-xarray.ipynb
+++ b/core/xarray/enso-xarray.ipynb
@@ -41,8 +41,8 @@
     "\n",
     "| Concepts | Importance | Notes |\n",
     "| --- | --- | --- |\n",
-    "| [Introduction to Xarray](./xarray.ipynb) | Necessary | |\n",
-    "| [Computation and Masking](./computation-masking.ipynb) | Necessary | |\n",
+    "| [Introduction to Xarray](xarray-intro) | Necessary | |\n",
+    "| [Computation and Masking](computation-masking) | Necessary | |\n",
     "\n",
     "\n",
     "\n",
@@ -380,7 +380,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   },
   "toc-autonumbering": false,
   "toc-showcode": false,

--- a/core/xarray/xarray-intro.ipynb
+++ b/core/xarray/xarray-intro.ipynb
@@ -930,7 +930,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR adds the Xarray logo to the section landing page, removes the "under construction" message (addressing #231), and renames the first notebook to `xarray-intro.ipynb` (updating internal links appropriately)