### PR TITLE
More polishing of GitHub sections

### DIFF
--- a/_toc.yml
+++ b/_toc.yml
@@ -32,7 +32,6 @@ parts:
           - file: foundations/github/github-pull-request
           - file: foundations/github/github-workflows
           - file: foundations/github/contribute-to-pythia
-          - file: foundations/github/github-advanced
   - caption: Core Scientific Python packages
     chapters:
       - file: core/overview

--- a/foundations/getting-started-github.md
+++ b/foundations/getting-started-github.md
@@ -1,3 +1,8 @@
+```{image} ../images/GitHub-logo.png
+:alt: GitHub Logo
+:width: 600px
+```
+
 # Getting started with GitHub
 
 Python and Jupyter are cool technologies, but they only scratch the surface of why you might want to adopt Python for your geoscience workflow.
@@ -10,8 +15,9 @@ We will walk users through these topics:
 - [What are GitHub repositories](github/github-repos), and what are some Python-specific examples?
 - [Issues and Discussions](github/github-issues) on GitHub: what they're for and how to participate
 - [Cloning and forking a repository](github/github-cloning-forking) (and what's the difference?)
-- [Detailed GitHub configuration](github/github-advanced) including how to set up secure permissions and notifications
+- [Detailed GitHub configuration](github/github-setup-advanced) including how to set up secure permissions and notifications
 - [Basic version control with _git_](github/basic-git): why you may need it, and how to get started
 - [What is a git _branch_?](github/git-branches)
 - [What's a Pull Request](github/github-pull-request), and how do you open one?
+- [GitHub Workflows](github/github-workflows), sets of best practices for collaborative work
 - [Contributing to Project Pythia via GitHub](github/contribute-to-pythia)

--- a/foundations/github/basic-git.md
+++ b/foundations/github/basic-git.md
@@ -1,7 +1,6 @@
 ```{image} ../../images/Git-Logo-2Color.png
 :alt: Git Logo
-:width: 600px
-:align: center
+:width: 400px
 ```
 
 # Basic version control with git

--- a/foundations/github/contribute-to-pythia.md
+++ b/foundations/github/contribute-to-pythia.md
@@ -1,3 +1,8 @@
+```{image} ../../images/GitHub-logo.png
+:alt: GitHub Logo
+:width: 400px
+```
+
 # Contribute to Project Pythia via GitHub
 
 ## Overview:

--- a/foundations/github/git-branches.md
+++ b/foundations/github/git-branches.md
@@ -1,7 +1,6 @@
 ```{image} ../../images/Git-Logo-2Color.png
 :alt: Git Logo
-:width: 600px
-:align: center
+:width: 400px
 ```
 
 # Git Branches

--- a/foundations/github/github-cloning-forking.md
+++ b/foundations/github/github-cloning-forking.md
@@ -1,3 +1,8 @@
+```{image} ../../images/GitHub-logo.png
+:alt: GitHub Logo
+:width: 400px
+```
+
 # Cloning and Forking a Repository
 
 ## Overview:

--- a/foundations/github/github-issues.md
+++ b/foundations/github/github-issues.md
@@ -1,3 +1,8 @@
+```{image} ../../images/GitHub-logo.png
+:alt: GitHub Logo
+:width: 400px
+```
+
 # Issues and Discussions
 
 ## Overview:

--- a/foundations/github/github-pull-request.md
+++ b/foundations/github/github-pull-request.md
@@ -1,7 +1,6 @@
-```{image} ../../images/Git-Logo-2Color.png
-:alt: Git Logo
-:width: 600px
-:align: center
+```{image} ../../images/GitHub-logo.png
+:alt: GitHub Logo
+:width: 400px
 ```
 
 # Opening a Pull Request on GitHub

--- a/foundations/github/github-repos.md
+++ b/foundations/github/github-repos.md
@@ -1,3 +1,8 @@
+```{image} ../../images/GitHub-logo.png
+:alt: GitHub Logo
+:width: 400px
+```
+
 # GitHub repositories
 
 ## Overview:

--- a/foundations/github/github-setup-advanced.md
+++ b/foundations/github/github-setup-advanced.md
@@ -1,4 +1,9 @@
-# Advanced GitHub Setup
+```{image} ../../images/GitHub-logo.png
+:alt: GitHub Logo
+:width: 400px
+```
+
+# Configuring your GitHub account
 
 ## Overview:
 

--- a/foundations/github/github-workflows.md
+++ b/foundations/github/github-workflows.md
@@ -1,7 +1,6 @@
 ```{image} ../../images/Git-Logo-2Color.png
 :alt: Git Logo
-:width: 600px
-:align: center
+:width: 400px
 ```
 
 # GitHub Workflows
@@ -24,7 +23,7 @@ A workflow is a series of activities or tasks that must be completed sequentiall
 | [Basic version control with git](basic-git)   | Necessary   |       |
 | [Issues and Discussions](github-issues)       | Recommended |       |
 | [Branches](github-issues)                     | Necessary   |       |
-| [Pull Requests](github-pull-requests)         | Necessary   |       |
+| [Pull Requests](github-pull-request)          | Necessary   |       |
 
 - **Time to learn**: 60 minutes
 

--- a/foundations/github/what-is-github.md
+++ b/foundations/github/what-is-github.md
@@ -1,4 +1,7 @@
-<img src="../../images/GitHub-logo.png" alt="Github Logo" width="600px">
+```{image} ../../images/GitHub-logo.png
+:alt: GitHub Logo
+:width: 400px
+```
 
 # What is GitHub?
 


### PR DESCRIPTION
This PR does the following:
- Uses more consistent logos through the GitHub sections (including the landing page)
- Fixes the list of topics and links on the landing page
- Removes the placeholder "Advanced topics" notebook from the TOC (the notebook file is still there in the repo in case we want to populate it later)
- Renames the "Advanced GitHub Setup" section to "Configuring your GitHub account" (sounds less scary)