### PR TITLE
environment.yml: do not constrain 'python' to 3.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - pre-commit
   - pyproj
   - pythia-datasets
-  - python=3.8
+  - python
   - scipy
   - ffmpeg
   - sqlalchemy<1.4


### PR DESCRIPTION
The environment that conda (or mamba) creates from this file on Windows
does not work; importing 'pythia_datasets' results in a cryptic error:

    ImportError: DLL load failed while importing shell: The specified procedure could not be found.

It seems there is some incompatibility between 'pywin32', a dependency
of 'jupyter_core' on Windows, and 'appdirs' (a dependency of
pythia_dataset's dependency 'pooch'), at least under Python 3.8.

Fix this by lifting the version constrain on the 'python' package. This
creates an environment with Python 3.10, where importing
'pythia_datasets' works correctly.

Closes: https://github.com/ProjectPythia/pythia-foundations/issues/277

<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
