### PR TITLE
Fixed spelling error and clarified text.

### DIFF
--- a/foundations/jupyterlab.ipynb
+++ b/foundations/jupyterlab.ipynb
@@ -243,9 +243,9 @@
     "id": "b0Zv8pF8e7Y0"
    },
    "source": [
-    "## Runnning JupyterLab Notebooks\n",
+    "## Running JupyterLab Notebooks\n",
     "\n",
-    "There are two ways to open a Jupyter Notebook. One way is to select the File Browser Tab, click the \"New Launcher\" button, and select a Python 3 Notebook from the Launcher. Another way is to go to the top Menu Bar, hover over the File Menu, and select \"New Notebook.\" JupyterLab will prompt you with a dialogue box to select the Kernel you want to use in your Notebook. Select the “Python 3” kernel.\n",
+    "There are two ways to open a Jupyter Notebook. One way is to select the File Browser Tab, click the \"New Launcher\" button, and select a Python 3 Notebook from the Launcher. Another way is to go to the top Menu Bar and select File&#9654;New&#9654;Notebook. JupyterLab will prompt you with a dialogue box to select the Kernel you want to use in your Notebook. Select the “Python 3” kernel.\n",
     "\n",
     "If you have the File Browser Tab open, notice you just created a file called `Untitled.ipynb.` You will also have a new window open in the main work area for your new Notebook.\n",
     "\n",
@@ -606,7 +606,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Corrected the spelling of "Running" in the section "Running JupyterLab Notebooks" in "Getting Started with Jupyter," and clarified the text in the first paragraph.

In the text clarification, I used HTML Entities. These render slightly different in Jupyter Lab then they do in the generated HTML.
