### PR TITLE
fix cookbook navlink

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -128,7 +128,7 @@ sphinx:
         - name: Resources
           url: https://projectpythia.org/resource-gallery.html
         - name: Cookbooks
-          url: https://projectpythia.org/cookbooks.html
+          url: https://projectpythia.org/cookbook-gallery.html
         - name: Community
           url: https://projectpythia.org/index.html#join-us
       footer_logos:


### PR DESCRIPTION
The navlink to cookbooks in the Foundations page goes to the old placeholder `cookbooks` page. It is now broken because of https://github.com/ProjectPythia/projectpythia.github.io/pull/243 and needs to be updated.
