### PR TITLE
Reording Navbar links to prioritize Pythia produced content

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -125,10 +125,10 @@ sphinx:
           url: https://projectpythia.org
         - name: Foundations
           url: https://foundations.projectpythia.org
-        - name: Resources
-          url: https://projectpythia.org/resource-gallery.html
         - name: Cookbooks
           url: https://projectpythia.org/cookbook-gallery.html
+        - name: Resources
+          url: https://projectpythia.org/resource-gallery.html
         - name: Community
           url: https://projectpythia.org/index.html#join-us
       footer_logos:


### PR DESCRIPTION
Putting Cookbooks before Resources. This is also done on the Portal in https://github.com/ProjectPythia/projectpythia.github.io/pull/256 and will be need to be done in the Cookbooks template and each cookbook as well.
