### PR TITLE
Updates references to display as links

### DIFF
--- a/core/numpy/numpy-broadcasting.ipynb
+++ b/core/numpy/numpy-broadcasting.ipynb
@@ -907,7 +907,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Resources and references\n",
+    "## Resources and references\n",
     "* [NumPy Broadcasting Documentation](https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html)"
    ]
   }

--- a/core/numpy/numpy-broadcasting.ipynb
+++ b/core/numpy/numpy-broadcasting.ipynb
@@ -908,8 +908,7 @@
    "metadata": {},
    "source": [
     "### Resources and references\n",
-    "* [NumPy Broadcasting Documentation](https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html)\n",
-    "* [NumPy Broadcasting Article](https://numpy.org/devdocs/user/theory.broadcasting.html)"
+    "* [NumPy Broadcasting Documentation](https://docs.scipy.org/doc/numpy/user/basics.broadcasting.html)"
    ]
   }
  ],
@@ -929,7 +928,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.2"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,

--- a/foundations/github/git-branches.md
+++ b/foundations/github/git-branches.md
@@ -297,8 +297,8 @@ All in all your Git Branching workflow should resemble this flow:
 
 [Opening a Pull Request on GitHub](github-pull-request)
 
-## References
+## Resources and references
 
-1. “GitHub.com Help Documentation.” GitHub Docs, https://docs.github.com/en.
-2. Paul, Kevin. “Python Tutorial Seminar Series - Github.” Project Pythia, YouTube, 12 May 2021, https://www.youtube.com/watch?v=fYkPn0Nttlg.
-3. “Resolving a Merge Conflict Using the Command Line.” GitHub Docs, https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line.
+- [GitHub.com Help Documentation (GitHub Docs)](https://docs.github.com/en)
+- Paul, Kevin. [Python Tutorial Seminar Series - Github (Project Pythia, YouTube, 12 May 2021)](https://www.youtube.com/watch?v=fYkPn0Nttlg)
+- [Resolving a Merge Conflict Using the Command Line (GitHub Docs)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line)

--- a/foundations/github/git-branches.md
+++ b/foundations/github/git-branches.md
@@ -300,5 +300,5 @@ All in all your Git Branching workflow should resemble this flow:
 ## Resources and references
 
 - [GitHub.com Help Documentation (GitHub Docs)](https://docs.github.com/en)
-- Paul, Kevin. [Python Tutorial Seminar Series - Github (Project Pythia, YouTube, 12 May 2021)](https://www.youtube.com/watch?v=fYkPn0Nttlg)
+- [Xdev Python Tutorial Seminar Series - Github (Kevin Paul)](https://www.youtube.com/watch?v=fYkPn0Nttlg)
 - [Resolving a Merge Conflict Using the Command Line (GitHub Docs)](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-using-the-command-line)


### PR DESCRIPTION
This PR updates the "References" section of git-branches.md to make references display as links. It also deletes a redundant link in the "Resources and references" section of numpy-broadcasting.ipynb and changes the heading level of that section to "##" instead of "###".

It didn't seem like there was consistent styling of the "Resources and references" sections throughout the book. For example, pages use "Resources and references", "References", or "Additional Resources" as the section title. Some of these sections use numbered lists while others use bulleted lists. I tried to make the changes I made blend in with the rest of the book, but if more consistency is wanted I can create an issue for that.   