### PR TITLE
Issue 64

### DIFF
--- a/foundations/quickstart.ipynb
+++ b/foundations/quickstart.ipynb
@@ -462,7 +462,7 @@
     "\n",
     "The vast majority of scientific Python code makes use of *packages* that extend the base language in many useful ways.\n",
     "\n",
-    "Almost all scientific computing requires ordered arrays of numbers, and fast methods for manipulating them. That's what NumPy does in the Python world.\n",
+    "Almost all scientific computing requires ordered arrays of numbers, and fast methods for manipulating them. That's what [NumPy](../core/numpy.md) does in the Python world.\n",
     "\n",
     "Using any package requires an `import` statement, and (optionally) a nickname to be used locally, denoted by the keyword `as`:"
    ]
@@ -510,7 +510,7 @@
    "id": "cc1c2474",
    "metadata": {},
    "source": [
-    "We've just created a new type of object defined by NumPy:"
+    "We've just created a new type of object defined by [NumPy](../core/numpy.md):"
    ]
   },
   {
@@ -566,7 +566,7 @@
    "source": [
     "## Some basic graphics with Matplotlib\n",
     "\n",
-    "Matplotlib is the standard package for producing publication-quality graphics, and works hand-in-hand with NumPy arrays.\n",
+    "[Matplotlib](../core/matplotlib.md) is the standard package for producing publication-quality graphics, and works hand-in-hand with [NumPy](../core/numpy.md) arrays.\n",
     "\n",
     "We usually use the `pyplot` submodule for day-to-day plotting commands:"
    ]

--- a/foundations/quickstart.ipynb
+++ b/foundations/quickstart.ipynb
@@ -458,11 +458,11 @@
    "id": "fb82a430",
    "metadata": {},
    "source": [
-    "## Arrays of numbers with `numpy`\n",
+    "## Arrays of numbers with NumPy\n",
     "\n",
     "The vast majority of scientific Python code makes use of *packages* that extend the base language in many useful ways.\n",
     "\n",
-    "Almost all scientific computing requires ordered arrays of numbers, and fast methods for manipulating them. That's what numpy does in the Python world.\n",
+    "Almost all scientific computing requires ordered arrays of numbers, and fast methods for manipulating them. That's what NumPy does in the Python world.\n",
     "\n",
     "Using any package requires an `import` statement, and (optionally) a nickname to be used locally, denoted by the keyword `as`:"
    ]
@@ -510,7 +510,7 @@
    "id": "cc1c2474",
    "metadata": {},
    "source": [
-    "We've just created a new type of object defined by numpy:"
+    "We've just created a new type of object defined by NumPy:"
    ]
   },
   {
@@ -564,9 +564,9 @@
    "id": "ebf2b669",
    "metadata": {},
    "source": [
-    "## Some basic graphics with `matplotlib`\n",
+    "## Some basic graphics with Matplotlib\n",
     "\n",
-    "matplotlib is the standard package for producing publication-quality graphics, and works hand-in-hand with numpy arrays.\n",
+    "Matplotlib is the standard package for producing publication-quality graphics, and works hand-in-hand with NumPy arrays.\n",
     "\n",
     "We usually use the `pyplot` submodule for day-to-day plotting commands:"
    ]
@@ -617,6 +617,16 @@
     "\n",
     "Read on for more details on how to install and run Python and necessary packages on your own laptop."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edbbb2ad-4544-4564-9750-6d738698fe2e",
+   "metadata": {},
+   "source": [
+    "## Resources and references\n",
+    "\n",
+    "- [Official Python tutorial (Python Docs)](https://docs.python.org/3/tutorial/index.html)"
+   ]
   }
  ],
  "metadata": {
@@ -635,7 +645,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.10.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This pull request makes the capitalization of NumPy and Matplotlib in quickstart.ipynb consistent with other pages in the Pythia Foundations book. It adds links to Project Pythia NumPy and Matplotlib content. A "Resources and references" section was added with one link to [Official Python tutorial (Python Docs)](https://docs.python.org/3/tutorial/index.html).  
