### PR TITLE
Update link to Jupyter logo

### DIFF
--- a/foundations/getting-started-jupyter.ipynb
+++ b/foundations/getting-started-jupyter.ipynb
@@ -6,7 +6,7 @@
     "id": "RYdHzMOHLr1U"
    },
    "source": [
-    "<img src=\"https://datascience.foundation/backend/web/uploads/blog/Working-with-Python-on-Cloud.png\"></img>"
+    "<img src=\"https://jupyter.org/assets/homepage/main-logo.svg\"></img>"
    ]
   },
   {

--- a/foundations/getting-started-jupyter.ipynb
+++ b/foundations/getting-started-jupyter.ipynb
@@ -6,7 +6,7 @@
     "id": "RYdHzMOHLr1U"
    },
    "source": [
-    "<img src=\"https://jupyter.org/assets/homepage/main-logo.svg\"></img>"
+    "<img src=\"https://jupyter.org/assets/homepage/main-logo.svg\" width="400"></img>"
    ]
   },
   {


### PR DESCRIPTION
Fixes #328. Note that the new SVG logo is quite a bit smaller than the PNG that we linked to before, but IMHO it's ok.
