### PR TITLE
Pin xarray version < 2022.11.0 to fix nc_time_axis import bug in that…

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - scipy
   - ffmpeg
   - sqlalchemy<1.4
-  - xarray
+  - xarray<2022.11.0
   - python-graphviz
   - graphviz
   - pip:


### PR DESCRIPTION
Resolves #343 for now. We can likely remove the pin with the next release of xarray. 

We'll also need to do a similar pin for any cookbooks that rely on an `nc_time_axis` import.
