### PR TITLE
Demo: execute notebooks on Pythia binder

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,10 +13,7 @@ exclude_patterns:
 
 execute:
   # See https://jupyterbook.org/content/execute.html
-  execute_notebooks: force
-  #   "auto" should only execute those notebooks that don't have output in all cells.
-  #   "force" : force execution of all notebooks
-  #   "cache": Cache output of notebooks on each build.
+  execute_notebooks: binder
   timeout: 600
   # Cells that are expected to fail (for pedagogical reasons) should set the cell tag `raises-exceptions`
   allow_errors: False
@@ -112,7 +109,7 @@ sphinx:
           icon: fab fa-youtube-square
           type: fontawesome
       launch_buttons:
-        binderhub_url: https://mybinder.org
+        binderhub_url: http://binder.mypythia.org
         notebook_interface: jupyterlab
       extra_navbar: |
         Theme by <a href="https://projectpythia.org">Project Pythia</a>.<br><br>


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This shows how, with the Cookbook infrastructure, we can easily switch to executing all notebooks on a Binder instance.