### PR TITLE
Add Zenodo badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![nightly-build](https://github.com/ProjectPythia/pythia-foundations/actions/workflows/nightly-build.yaml/badge.svg)](https://github.com/ProjectPythia/pythia-foundations/actions/workflows/nightly-build.yaml)
 
+[![DOI](https://zenodo.org/badge/338145160.svg)](https://zenodo.org/badge/latestdoi/338145160)
+
 This is the source repository for the Pythia Foundations content collection.
 
 The rendered site can be found at https://foundations.projectpythia.org


### PR DESCRIPTION
Adds link to the Zenodo page for the foundations book release. 

Points to consider: badge link needs to be updated with new releases, still need to add prominent how to cite section.

Related to #309 and #344