### PR TITLE
Remove old version pins from environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -15,9 +15,8 @@ dependencies:
   - pyproj
   - pythia-datasets
   - python
-  - scipy<1.11
+  - scipy
   - ffmpeg
-  - sqlalchemy<1.4
   - xarray
   - python-graphviz
   - graphviz


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Seeing if we can now remove two likely-obsolete version pins from the environment file.

The scipy pin was introduced recently in https://github.com/ProjectPythia/pythia-foundations/pull/414 waiting until the next Cartopy release. That has happened so we shouldn't need the pin anymore.

The other pin is much older, dating back to the first introduction of the Cartopy notebook https://github.com/ProjectPythia/pythia-foundations/pull/24. I'm not sure the original reason this was needed, but I suspect it's obsolete now.

Testing to see if everything works!