### PR TITLE
Clarify Array Slicing Syntax from 'array[start:stop[:step]]' to 'array[start:stop:step]'

### DIFF
--- a/core/numpy/numpy-basics.ipynb
+++ b/core/numpy/numpy-basics.ipynb
@@ -700,7 +700,7 @@
    "source": [
     "### Slices\n",
     "\n",
-    "Slicing syntax is written as `array[start:stop:step]'. Note that **all numbers are optional**. Importantly, the **step** parameter is optional and can be omitted, in which case the slice uses a default step of 1.\n",
+    "Slicing syntax is written as `array[start:stop:step]`. Note that **all numbers are optional**. Importantly, the **step** parameter is optional and can be omitted, in which case the slice uses a default step of 1.\n",
     "- defaults: \n",
     "  - start = 0\n",
     "  - stop = len(dim)\n",

--- a/core/numpy/numpy-basics.ipynb
+++ b/core/numpy/numpy-basics.ipynb
@@ -700,7 +700,7 @@
    "source": [
     "### Slices\n",
     "\n",
-    "Slicing syntax is written as `array[start:stop:step]`, where **all numbers are optional**.\n",
+    "Slicing syntax is written as `array[start:stop:step]'. Note that **all numbers are optional**. Importantly, the **step** parameter is optional and can be omitted, in which case the slice uses a default step of 1.\n",
     "- defaults: \n",
     "  - start = 0\n",
     "  - stop = len(dim)\n",

--- a/core/numpy/numpy-basics.ipynb
+++ b/core/numpy/numpy-basics.ipynb
@@ -700,7 +700,7 @@
    "source": [
     "### Slices\n",
     "\n",
-    "Slicing syntax is written as `array[start:stop[:step]]`, where **all numbers are optional**.\n",
+    "Slicing syntax is written as `array[start:stop:step]`, where **all numbers are optional**.\n",
     "- defaults: \n",
     "  - start = 0\n",
     "  - stop = len(dim)\n",


### PR DESCRIPTION

This pull request updates the array slicing syntax documentation. The original syntax notation 'array[start:stop[:step]]' could be misinterpreted as suggesting the step parameter is nested within the stop parameter. This update simplifies the notation to 'array[start:stop:step]', clearly delineating each parameter, enhancing readability and reducing potential confusion for users.