### PR TITLE
Change admonitions

### DIFF
--- a/core/xarray/computation-masking.ipynb
+++ b/core/xarray/computation-masking.ipynb
@@ -335,11 +335,10 @@
    "id": "5d176ad8-15f1-4ecc-ab3e-898cef3b4e18",
    "metadata": {},
    "source": [
-    "<div class=\"admonition alert alert-info\">\n",
+    "```{admonition} Info\n",
+    ":class: tip\n",
     "\n",
-    "In the above code example, we are extracting components of date/time data by way of the time coordinate's `.dt` attribute. This attribute is a `DatetimeAccessor` object that contains additional attributes for units of time, such as hour, day, and year. Since we are splitting the data into monthly data, we use the `month` attribute of .dt in this example. (In addition, there exists similar functionality in Pandas; see the [official documentation](https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.month.html) for details.)\n",
-    "    \n",
-    "   </div>"
+    "In the above code example, we are extracting components of date/time data by way of the time coordinate's `.dt` attribute. This attribute is a `DatetimeAccessor` object that contains additional attributes for units of time, such as hour, day, and year. Since we are splitting the data into monthly data, we use the `month` attribute of .dt in this example. (In addition, there exists similar functionality in Pandas; see the [official documentation](https://pandas.pydata.org/docs/reference/api/pandas.Series.dt.month.html) for details.)"
    ]
   },
   {
@@ -505,12 +504,10 @@
    "id": "d9f768be-a960-4417-bb1e-9785ca9ca4ea",
    "metadata": {},
    "source": [
-    "<div class=\"admonition alert alert-warning\">\n",
-    "   \n",
+    "```{admonition} Info\n",
+    ":class: warning\n",
     "\n",
-    "Many geoscientific algorithms perform operations over data contained in many different grid cells. However, if the grid cells are not equivalent in size, the operation is not scientifically valid by default. Fortunately, this can be fixed by weighting the data in each grid cell by the size of the cell. Weighting data in Xarray is simple, as Xarray has a built-in weighting method, known as [`.weighted()`](https://xarray.pydata.org/en/stable/user-guide/computation.html#weighted-array-reductions).\n",
-    "\n",
-    "</div>\n"
+    "Many geoscientific algorithms perform operations over data contained in many different grid cells. However, if the grid cells are not equivalent in size, the operation is not scientifically valid by default. Fortunately, this can be fixed by weighting the data in each grid cell by the size of the cell. Weighting data in Xarray is simple, as Xarray has a built-in weighting method, known as [`.weighted()`](https://xarray.pydata.org/en/stable/user-guide/computation.html#weighted-array-reductions).\n"
    ]
   },
   {

--- a/core/xarray/dask-arrays-xarray.ipynb
+++ b/core/xarray/dask-arrays-xarray.ipynb
@@ -167,12 +167,10 @@
    "id": "ebbafe88-bb79-436c-aa3b-a9c5f31ff1ec",
    "metadata": {},
    "source": [
-    "<div class=\"admonition alert alert-info\">\n",
-    "    <p class=\"admonition-title\" style=\"font-weight:bold\">Specifying Chunks</p>\n",
-    "    In this tutorial, we specify Dask Array chunks in a block shape. However, there are many additional ways to specify chunks; see <a href=\"https://docs.dask.org/en/latest/array-chunks.html\">this documentation</a> for more details.\n",
+    "```{admonition} Specifying Chunks\n",
+    ":class: tip\n",
     "\n",
-    "</div>\n",
-    "\n"
+    "In this tutorial, we specify Dask Array chunks in a block shape. However, there are many additional ways to specify chunks; see [this documentation](https://docs.dask.org/en/latest/array-chunks.html) for more details."
    ]
   },
   {

--- a/foundations/conda.md
+++ b/foundations/conda.md
@@ -110,7 +110,7 @@ conda env list
 conda env remove --name sample_environment
 ```
 
-You can find lots more information in the [Conda documentation](https://docs.conda.io/en/latest/) or this handy [Conda cheat sheet](https://docs.conda.io/projects/conda/en/latest/_downloads/843d9e0198f2a193a3484886fa28163c/conda-cheatsheet.pdf).
+You can find lots more information in the [Conda documentation](https://docs.conda.io/en/latest/) or this handy [Conda cheat sheet](https://docs.conda.io/projects/conda/en/4.6.0/_downloads/52a95608c49671267e40c689e0bc00ca/conda-cheatsheet.pdf).
 
 If you're not a command line user, the Anaconda navigator offers GUI functionality for selecting environments and installing packages.
 

--- a/foundations/conda.md
+++ b/foundations/conda.md
@@ -129,6 +129,6 @@ Conda is a package and environment management system that allows you to quickly 
 
 - [Linux commands](https://cheatography.com/davechild/cheat-sheets/linux-command-line/)
 - [Conda documentation](https://docs.conda.io/en/latest/)
-- [Conda cheat sheet](https://docs.conda.io/projects/conda/en/latest/_downloads/843d9e0198f2a193a3484886fa28163c/conda-cheatsheet.pdf)
+- [Conda cheat sheet](https://docs.conda.io/projects/conda/en/4.6.0/_downloads/52a95608c49671267e40c689e0bc00ca/conda-cheatsheet.pdf)
 - [Anaconda](https://docs.anaconda.com/anaconda/install/)
 - [Miniconda](https://docs.conda.io/en/latest/miniconda.html)


### PR DESCRIPTION
With the new sphinx theme, admonitions are called like 
```
```{admonition} Info
:class: tip

In the above code example, we are extract ...
```
The HTML `<div> ...` version was causing the issues. This is isolated to these two files and doesn't require an overall theme adjustment.

Closes https://github.com/ProjectPythia/sphinx-pythia-theme/issues/64