### PR TITLE
Remove cname argument to deploy-book workflow

### DIFF
--- a/.github/workflows/publish-book.yaml
+++ b/.github/workflows/publish-book.yaml
@@ -16,5 +16,3 @@ jobs:
   deploy:
     needs: build
     uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main
-    with:
-      cname: foundations.projectpythia.org

--- a/.github/workflows/trigger-preview.yaml
+++ b/.github/workflows/trigger-preview.yaml
@@ -18,7 +18,6 @@ jobs:
       artifact_name: book-zip-${{ needs.find-pull-request.outputs.number }}
       destination_dir: _preview/${{ needs.find-pull-request.outputs.number }} # deploy to subdirectory labeled with PR number
       is_preview: "true"
-      cname: foundations.projectpythia.org
 
   preview-comment:
     needs: find-pull-request


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This needs doing for consistency with https://github.com/ProjectPythia/cookbook-actions/pull/135

Publishing of the preview is expected to fail here.