### PR TITLE
fix: update metadata URLs

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -1,10 +1,10 @@
 # See docs at: https://mystmd.org/guide/frontmatter
 version: 1
 extends:
-  - https://raw.githubusercontent.com/projectpythia-mystmd/pythia-config/main/pythia.yml
+  - https://raw.githubusercontent.com/projectpythia/pythia-config/main/pythia.yml
 project:
   title: Pythia Foundations
-  github: https://github.com/projectpythia-mystmd/pythia-foundations
+  github: https://github.com/projectpythia/pythia-foundations
   author:
     - Project Pythia Community
   copyright: '2024'


### PR DESCRIPTION
Replaces links to `projectpythia-mystmd` with their `projectpythia` counterparts.