### PR TITLE
Update nightly-build.yaml

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -12,6 +12,10 @@ jobs:
     with:
       base_url: ''
 
+  deploy:
+    needs: build
+    uses: ProjectPythia/cookbook-actions/.github/workflows/deploy-book.yaml@main
+
   link-check:
     if: ${{ github.repository_owner == 'ProjectPythia' }}
     uses: ProjectPythia/cookbook-actions/.github/workflows/link-checker.yaml@main


### PR DESCRIPTION
Nightly build on foundations should have deploy step too

Curious if the current failure is the reason this wasn't there before :)