### PR TITLE
Fix typo from 'call' to 'called'

### DIFF
--- a/core/xarray/computation-masking.ipynb
+++ b/core/xarray/computation-masking.ipynb
@@ -95,7 +95,7 @@
    "source": [
     "## Data Setup\n",
     "\n",
-    "The bulk of the examples in this tutorial make use of a single dataset. This dataset contains monthly sea surface temperature (SST, call 'tos' here) data, and is obtained from the Community Earth System Model v2 (CESM2). (For this tutorial, however, the dataset will be retrieved from the Pythia example data repository.) The following example illustrates the process of retrieving this Global Climate Model dataset:"
+    "The bulk of the examples in this tutorial make use of a single dataset. This dataset contains monthly sea surface temperature (SST, called 'tos' here) data, and is obtained from the Community Earth System Model v2 (CESM2). (For this tutorial, however, the dataset will be retrieved from the Pythia example data repository.) The following example illustrates the process of retrieving this Global Climate Model dataset:"
    ]
   },
   {


### PR DESCRIPTION
Fixed typo in pythia core xarray notebook computation-masking.ipynb