### PR TITLE
Add footer with updated text

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -88,3 +88,38 @@ project:
         - file: appendix/how-to-contribute.md
           children:
             - file: appendix/template.ipynb
+
+site:
+  parts:
+    footer: |
+        :::::{grid} 4
+        :class: items-center
+
+        ```{image} https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/UAlbany.svg
+        :alt: UAlbany Logo
+        ```
+
+        ```{image} https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/NSF-NCAR.png
+        :alt: NCAR Logo
+        ```
+
+        ```{image} https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/NSF-Unidata.png
+        :alt: Unidata Logo
+        ```
+        
+        ```{image} https://raw.githubusercontent.com/2i2c-org/2i2c-org.github.io/main/assets/media/logo.svg
+        :alt: 2i2c Logo
+        ```
+        
+        :::::
+
+        :::::{div}
+        :class: flex items-center gap-4 text-disclaimer
+
+        ```{image} https://raw.githubusercontent.com/ProjectPythia/pythia-config/main/logos/nsf.jpg
+        :alt: NSF Logo
+        :height: 60px
+        ```
+
+        The [Project Pythia website](https://projectpythia.org), [Pythia Foundations](https://foundations.projectpythia.org), and the shared [Cookbook](https://cookbooks.projectpythia.org) infrastructure are based upon work supported by the National Science Foundation awards 2026899, 2026863, 2324302, 2324303 and 2324304. Any opinions, findings, and conclusions or recommendations expressed in this material are those of the author(s) and do not necessarily reflect the views of the National Science Foundation.
+        :::::


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Closes #530 

This PR temporarily adds a footer directly to Foundations until the shared upstream footer problem is resolved (https://github.com/ProjectPythia/projectpythia.github.io/issues/530).

This PR also modifies the footer layout and text, following recent discussions. The footer text makes more specific claims about which parts of the Pythia content were supported by NSF awards, and updates the statement to include the current awards.

Finally, I included the 2i2c logo so that the collection of logos fully represents the current set of institutions covered by our NSF awards.

I'd like to settle on the new text here, and use this as a template for the [upstream shared footer](https://github.com/ProjectPythia/pythia-config/blob/main/pythia.yml). We can also update the [temporary footer on the portal site](https://github.com/ProjectPythia/projectpythia.github.io/blob/main/portal/myst.yml) to match this once we settle and merge this.  