### PR TITLE
Add Brittany and Katelyn to the CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -40,11 +40,19 @@ authors:
     orcid: https://orcid.org/0000-0002-0370-8974
     website: https://github.com/mgrover1
     affiliation: Argonne National Laboratory
+  - family-names: FitzGerald
+    given-names: Katelyn
+    orcid: https://orcid.org/0000-0003-4184-1917
+    affiliation: UCAR/NCAR
   - family-names: Ford
     given-names: Robert R.
     orcid: https://orcid.org/0000-0001-5483-4965
     website: https://github.com/r-ford
     affiliation: University at Albany (State University of New York)
+  - family-names: Freeman
+    given-names: Brittany
+    orcid: https://orcid.org/0009-0006-2806-1149
+    affilitation: University at Albany (State University of New York)
   - family-names: Paul
     given-names: Kevin
     orcid: https://orcid.org/0000-0001-8155-8038


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
We have different "sources of truth" about authorship of Pythia Foundations, which is not ideal.

This PR doesn't solve that problem but *does* add two authors who have made recent contributions (and who are also credited as co-authors of the JOSE paper) to the CITATION.cff file: @bl-freeman and @kafitzgerald 