### PR TITLE
Fix: DOI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Pythia Foundations
-
 [![nightly-build](https://github.com/ProjectPythia/pythia-foundations/actions/workflows/nightly-build.yaml/badge.svg)](https://github.com/ProjectPythia/pythia-foundations/actions/workflows/nightly-build.yaml)
-[![DOI](https://zenodo.org/badge/338145160.svg)](https://zenodo.org/badge/latestdoi/338145160)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.7884571.svg)](https://doi.org/10.5281/zenodo.7884571)
 [![status](https://jose.theoj.org/papers/6ad4fe1df16342a33f750b43772c1b15/status.svg)](https://jose.theoj.org/papers/6ad4fe1df16342a33f750b43772c1b15)
 
 This is the source repository for the Pythia Foundations content collection.


### PR DESCRIPTION
I noticed that the DOI badge wasn't rendering. I used the "link to all versions" DOI and followed the Zenodo scheme for building a badge URI to make this PR.