### PR TITLE
Add min version for mystmd

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,5 +18,5 @@ dependencies:
   - xarray
   - python-graphviz
   - graphviz
-  - mystmd
+  - mystmd>=1.6.0
   - jupyterlab-myst


### PR DESCRIPTION
Adds a minimum version for MyST MD to avoid some of the environment related issues we've been seeing.

I chose 1.6.0 in particular since there were some major changes the way static HTML files were generated including path changes so earlier versions will likely be problematic.

MyST MD release notes for reference: https://github.com/jupyter-book/mystmd/releases

Closes #595 