### PR TITLE
Add author Lily Kailyn with ORCID and affiliation

### DIFF
--- a/paper.md
+++ b/paper.md
@@ -41,6 +41,9 @@ authors:
   - name: Maxwell A. Grover
     orcid: 0000-0002-0370-8974
     affiliation: 5
+  - name: Lily Kailyn
+    orcid: 0009-0002-0125-5091
+    affiliation: 4
   - name: Julia Kent
     orcid: 0000-0002-5611-8986
     affiliation: 4


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR adds Lily Kailyn to the author list for the JOSE manuscript (consistent with the other sources of truth of about Foundations authorship).