### PR TITLE
Fix CF conventions web links

### DIFF
--- a/core/data-formats/netcdf-cf.ipynb
+++ b/core/data-formats/netcdf-cf.ipynb
@@ -943,7 +943,7 @@
     "      temperature:coordinates = \"lon lat heights time\" ;\n",
     "```\n",
     "\n",
-    "These standards for storing DSG data in netCDF files can be used for profiler data, as shown in these examples, as well as timeseries and trajectory data, and any combination of these types of data models. You can also use these standards for datasets with differing amounts of data in each feature, using so-called \"ragged\" arrays. For more information on ragged arrays, or other elements of the CF DSG standards, see the [main documentation page](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#discrete-sampling-geometries), or try some of the [annotated DSG examples](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#appendix-examples-discrete-geometries)."
+    "These standards for storing DSG data in netCDF files can be used for profiler data, as shown in these examples, as well as timeseries and trajectory data, and any combination of these types of data models. You can also use these standards for datasets with differing amounts of data in each feature, using so-called \"ragged\" arrays. For more information on ragged arrays, or other elements of the CF DSG standards, see the [main documentation page](https://cf-convention.github.io/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#discrete-sampling-geometries), or try some of the [annotated DSG examples](http://cf-convention.github.io/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html#appendix-examples-discrete-geometries)."
    ]
   },
   {
@@ -970,8 +970,8 @@
    "source": [
     "## Additional Resources\n",
     "\n",
-    "- [CF Conventions doc (1.7)](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html)\n",
-    "- [Jonathan Gregory's old CF presentation](http://cfconventions.org/Data/cf-documents/overview/viewgraphs.pdf)\n",
+    "- [CF Conventions doc (1.7)](https://cf-convention.github.io/Data/cf-conventions/cf-conventions-1.7/cf-conventions.html)\n",
+    "- [Jonathan Gregory's old CF presentation](https://cf-convention.github.io/Data/cf-documents/overview/viewgraphs.pdf)\n",
     "- [CF Data Model (cfdm) python package tutorial](https://ncas-cms.github.io/cfdm/tutorial.html)\n",
     "- [Tim Whiteaker's cfgeom python package (GitHub repo)](https://github.com/twhiteaker/CFGeom) and [(tutorial)]( https://twhiteaker.github.io/CFGeom/tutorial.html)\n",
     "- [netCDF4 Documentation](https://unidata.github.io/netcdf4-python/)"


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
As discussed in #617, builds are failing because links to https://cfconventions.org/ are down. This PR switches them all to the active https://cf-convention.github.io/ (shamelessly cribbing off @kafitzgerald)