### PR TITLE
Add IDE to the abbreviation list

### DIFF
--- a/myst.yml
+++ b/myst.yml
@@ -26,6 +26,7 @@ project:
     FTP: File Transfer Protocol
     HTTP: Hypertext Transfer Protocol
     ID: Identifier
+    IDE: Integrated Development Environment
     IDL: Interactive Data Language
     NCAR: NSF National Center for Atmospheric Research
     NCL: NCAR Command Language


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
I noticed that the abbreviation IDE is used quite a bit on [this How to Run Python page](https://foundations.projectpythia.org/foundations/how-to-run-python/), and it is causing a conflict with abbreviation identification because we already have "ID" as a supported abbreviation.

This PR just adds IDE to that list so that MyST gives useful help.