### PR TITLE
Update Markdown page with links

### DIFF
--- a/appendix/glossary.md
+++ b/appendix/glossary.md
@@ -88,6 +88,9 @@ Linux
 local
 : Refering to something, such as a {term}`Git` repository, on your computer rather than a remote server.
 
+Markdown
+: A simple, human-readable text language used extensively in {term}`Jupyter Notebooks`, on {term}`GitHub` and other code repositories, and elsewhere on the Internet (e.g., forums and blogs). Markdown lets us write readable plain text that can rendered as nicely styled text on web pages and other media, with headings, links, and other formatting.
+
 merge
 : A specific type of commit that combines changes from two branches.
 

--- a/foundations/markdown.md
+++ b/foundations/markdown.md
@@ -1,11 +1,11 @@
 # Formatted Text in the Notebook with Markdown
 
-Markdown is a simple, human-readable text language used extensively in Jupyter notebooks, on GitHub, and elsewhere. Markdown lets us write readable plain text that can rendered as nicely styled text on web pages and other media, with headings, links, and other formatting.
+{term}`Markdown` is a simple, human-readable text language used extensively in {term}`Jupyter Notebooks`, on {term}`GitHub`, and elsewhere. Markdown lets us write readable plain text that can rendered as nicely styled text on web pages and other media, with headings, links, and other formatting.
 
 Project Pythia uses [MyST Markdown](https://mystmd.org/), which is an extension of [CommonMark](https://commonmark.org/), which is in turn an implementation of [Markdown](wiki:Markdown).
 In fact the page you are reading right now was written in Markdown! See the [source on GitHub here](https://github.com/ProjectPythia/pythia-foundations/blob/main/foundations/markdown.md).
 
-Markdown was briefly mentioned in the previous section in the context of Jupyter notebooks. Here we provide a list of recommended resources for learning more.
+Markdown was briefly mentioned in the previous section in the context of {term}`Jupyter Notebooks`. Here we provide a list of recommended resources for learning more.
 - To learn the basics: the [CommonMark docs](https://commonmark.org/help/), including their [10-minute interactive tutorial](https://commonmark.org/help/tutorial/)
 - To learn some of the MyST-specific syntax: the [Introduction to MyST Markdown page](https://jupyterbook.org/stable/authoring/mystmd/) within the Jupyter Book User Guide
 - To learn everything that you can do with MyST: the [Authoring section of the MyST guide](https://mystmd.org/guide/typography)

--- a/foundations/markdown.md
+++ b/foundations/markdown.md
@@ -1,6 +1,9 @@
 # Formatted Text in the Notebook with Markdown
 
-Markdown is a simple, human-readable text language used extensively in Jupyter notebooks, on GitHub, and elsewhere. Project Pythia uses [MyST Markdown](https://mystmd.org/), which is an extension of [CommonMark](https://commonmark.org/), which is in turn an implementation of [Markdown](wiki:Markdown).
+Markdown is a simple, human-readable text language used extensively in Jupyter notebooks, on GitHub, and elsewhere. Markdown lets us write readable plain text that can rendered as nicely styled text on web pages and other media, with headings, links, and other formatting.
+
+Project Pythia uses [MyST Markdown](https://mystmd.org/), which is an extension of [CommonMark](https://commonmark.org/), which is in turn an implementation of [Markdown](wiki:Markdown). 
+In fact the page you are reading right now was written in Markdown! See the [source on GitHub here](https://github.com/ProjectPythia/pythia-foundations/blob/main/foundations/markdown.md).
 
 Markdown was briefly mentioned in the previous section in the context of Jupyter notebooks. Here we provide a list of recommended resources for learning more.
 - To learn the basics: the [CommonMark docs](https://commonmark.org/help/), including their [10-minute interactive tutorial](https://commonmark.org/help/tutorial/)

--- a/foundations/markdown.md
+++ b/foundations/markdown.md
@@ -2,7 +2,7 @@
 
 Markdown is a simple, human-readable text language used extensively in Jupyter notebooks, on GitHub, and elsewhere. Markdown lets us write readable plain text that can rendered as nicely styled text on web pages and other media, with headings, links, and other formatting.
 
-Project Pythia uses [MyST Markdown](https://mystmd.org/), which is an extension of [CommonMark](https://commonmark.org/), which is in turn an implementation of [Markdown](wiki:Markdown). 
+Project Pythia uses [MyST Markdown](https://mystmd.org/), which is an extension of [CommonMark](https://commonmark.org/), which is in turn an implementation of [Markdown](wiki:Markdown).
 In fact the page you are reading right now was written in Markdown! See the [source on GitHub here](https://github.com/ProjectPythia/pythia-foundations/blob/main/foundations/markdown.md).
 
 Markdown was briefly mentioned in the previous section in the context of Jupyter notebooks. Here we provide a list of recommended resources for learning more.

--- a/foundations/markdown.md
+++ b/foundations/markdown.md
@@ -1,9 +1,8 @@
 # Formatted Text in the Notebook with Markdown
 
-```{note}
-This content is under construction!
-```
+Markdown is a simple, human-readable text language used extensively in Jupyter notebooks, on GitHub, and elsewhere. Project Pythia uses [MyST Markdown](https://mystmd.org/), which is an extension of [CommonMark](https://commonmark.org/), which is in turn an implementation of [Markdown](wiki:Markdown).
 
-This section will give a tutorial on formatting text with Markdown: the simple, human-readable text language used extensively in Jupyter notebooks, GitHub Discussions, and elsewhere.
-
-We will show how this is useful both in notebooks and other places like GitHub Issues.
+Markdown was briefly mentioned in the previous section in the context of Jupyter notebooks. Here we provide a list of recommended resources for learning more.
+- To learn the basics: the [CommonMark docs](https://commonmark.org/help/), including their [10-minute interactive tutorial](https://commonmark.org/help/tutorial/)
+- To learn some of the MyST-specific syntax: the [Introduction to MyST Markdown page](https://jupyterbook.org/stable/authoring/mystmd/) within the Jupyter Book User Guide
+- To learn everything that you can do with MyST: the [Authoring section of the MyST guide](https://mystmd.org/guide/typography)

--- a/foundations/markdown.md
+++ b/foundations/markdown.md
@@ -1,9 +1,9 @@
 # Formatted Text in the Notebook with Markdown
 
-{term}`Markdown` is a simple, human-readable text language used extensively in {term}`Jupyter Notebooks`, on {term}`GitHub`, and elsewhere. Markdown lets us write readable plain text that can rendered as nicely styled text on web pages and other media, with headings, links, and other formatting.
+{term}`Markdown` is a simple, human-readable text language used extensively in {term}`Jupyter Notebooks`, on {term}`GitHub` and other code repositories, and elsewhere on the Internet (e.g., forums and blogs). Markdown lets us write readable plain text that can rendered as nicely styled text on web pages and other media, with headings, links, and other formatting.
 
 Project Pythia uses [MyST Markdown](https://mystmd.org/), which is an extension of [CommonMark](https://commonmark.org/), which is in turn an implementation of [Markdown](wiki:Markdown).
-In fact the page you are reading right now was written in Markdown! See the [source on GitHub here](https://github.com/ProjectPythia/pythia-foundations/blob/main/foundations/markdown.md).
+In fact, the page you are reading right now was written in Markdown! See the [source on GitHub here](https://github.com/ProjectPythia/pythia-foundations/blob/main/foundations/markdown.md).
 
 Markdown was briefly mentioned in the previous section in the context of {term}`Jupyter Notebooks`. Here we provide a list of recommended resources for learning more.
 - To learn the basics: the [CommonMark docs](https://commonmark.org/help/), including their [10-minute interactive tutorial](https://commonmark.org/help/tutorial/)

--- a/preamble/how-to-use.md
+++ b/preamble/how-to-use.md
@@ -2,7 +2,15 @@
 
 ## Overview
 
-Pythia Foundations is a geoscience-flavored introduction to essential tools in the Scientific Python Ecosystem (SPE) and [Pangeo](https://pangeo.io) stack. It covers the foundational knowledge that's needed to get started with Python in the computational geosciences, as well as to become an effective citizen-practitioner in key open geoscience software ecosystems. The intended audience is anyone from undergraduate students through established geoscientists who are relatively new to working in Python. The tutorials in this book also serve as references and prerequisites for the more advanced and domain-specific content in the [Pythia Cookbook Gallery](https://cookbooks.projectpythia.org).
+Pythia Foundations is a geoscience-flavored introduction to essential
+tools in the Scientific Python Ecosystem (SPE) and [Pangeo](https://pangeo.io)
+stack. It covers the foundational knowledge that's needed to get started
+with Python in the computational geosciences, as well as to become an
+effective citizen-practitioner in key open geoscience software ecosystems.
+The intended audience is anyone from undergraduate students through
+established geoscientists who are relatively new to working in Python.
+The tutorials in this book also serve as references and prerequisites
+for the more advanced and domain-specific content in the [Pythia Cookbook Gallery](https://cookbooks.projectpythia.org).
 
 ## What's included
 


### PR DESCRIPTION
As discussed in #232, we decided to link to existing Markdown tutorials instead of writing our own. I included three resources with varying levels of detail, but we could add more. This closes #232 and supersedes #248.