### PR TITLE
Pin PROJ < 9.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,3 +20,4 @@ dependencies:
   - graphviz
   - mystmd>=1.6.0
   - jupyterlab-myst
+  - proj<9.8

--- a/environment.yml
+++ b/environment.yml
@@ -20,4 +20,4 @@ dependencies:
   - graphviz
   - mystmd>=1.6.0
   - jupyterlab-myst
-  - proj<9.8
+  - proj<9.8  # See https://github.com/ProjectPythia/pythia-foundations/issues/653


### PR DESCRIPTION
Pins the version of PROJ to one that doesn't cause the feature misalignment issue with Cartopy.  In general, I don't love version pins, but I think this makes sense for the time being until it can be fixed upstream.  

Closes #653  (not sure if we want to leave this open instead and/or open a new issue as a reminder to remove this version pin once the issue has been addressed). 

